### PR TITLE
chore: remove PyO3 imports from Rust usage

### DIFF
--- a/qir_qis.pyi
+++ b/qir_qis.pyi
@@ -53,7 +53,7 @@ def qir_to_qis(
     """
 
 def validate_qir(
-    bc_bytes: builtins.bytes, wasm_bytes: builtins.bytes | None = None
+    bc_bytes: builtins.bytes, *, wasm_bytes: builtins.bytes | None = None
 ) -> None:
     r"""Validate the given QIR.
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1025,7 +1025,6 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use inkwell::{types::AnyType, values::BasicValue};
-    use pyo3::Python;
     use rstest::rstest;
 
     use std::fs;
@@ -1534,8 +1533,6 @@ mod tests {
 
         let qir_bytes = fs::read(&bc_path).expect("Failed to read input file");
 
-        Python::initialize();
-
         assert!(qir_qis::qir_to_qis(qir_bytes.into(), 2, "aarch64", None).is_err());
 
         if bc_path.exists() {
@@ -1549,8 +1546,6 @@ mod tests {
         let bc_path = get_bc(ll_path);
 
         let qir_bytes = fs::read(&bc_path).expect("Failed to read input file");
-
-        Python::initialize();
 
         assert!(qir_qis::validate_qir(qir_bytes.clone().into(), None).is_err());
         assert!(qir_qis::qir_to_qis(qir_bytes.into(), 2, "aarch64", None).is_err());
@@ -1566,8 +1561,6 @@ mod tests {
         let bc_path = get_bc(ll_path);
 
         let qir_bytes = fs::read(&bc_path).expect("Failed to read input file");
-
-        Python::initialize();
 
         assert!(qir_qis::qir_to_qis(qir_bytes.into(), 2, "aarch64", None).is_err());
 
@@ -1631,8 +1624,6 @@ mod tests {
 
         // Run the main function
         let qir_bytes = fs::read(&bc_path).expect("Failed to read input file");
-
-        Python::initialize();
 
         let qis_bytes = qir_qis::qir_to_qis(qir_bytes.into(), 2, "aarch64", None).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -922,10 +922,7 @@ mod aux {
     }
 }
 
-/// Core QIR to QIS translation logic without `PyO3` dependencies.
-///
-/// This function can be imported by other crates that need to use the translation
-/// logic without depending on `PyO3`.
+/// Core QIR to QIS translation logic.
 ///
 /// # Arguments
 /// - `bc_bytes` - The QIR bytes to translate.
@@ -1021,8 +1018,6 @@ pub fn qir_to_qis_core(
     Ok(module.write_bitcode_to_memory().as_slice().to_vec())
 }
 
-// Core Rust API functions (without PyO3 dependencies)
-
 #[cfg(feature = "wasm")]
 fn get_wasm_functions(
     wasm_bytes: Option<&[u8]>,
@@ -1048,8 +1043,6 @@ fn get_wasm_functions(
 }
 
 /// Validate the given QIR bitcode.
-///
-/// This is the core validation logic that can be used without `PyO3` dependencies.
 ///
 /// # Arguments
 /// - `bc_bytes` - The QIR bytes to validate.
@@ -1125,8 +1118,6 @@ pub fn validate_qir_core(bc_bytes: &[u8], wasm_bytes: Option<&[u8]>) -> Result<(
 }
 
 /// Convert QIR LLVM IR text to QIR bitcode bytes.
-///
-/// This is the core conversion logic that can be used without `PyO3` dependencies.
 ///
 /// # Errors
 /// Returns an error string if the LLVM IR is invalid.
@@ -1237,7 +1228,7 @@ pub mod qir_qis {
     #[gen_stub_pyfunction]
     #[pyfunction]
     #[allow(clippy::needless_pass_by_value)]
-    #[pyo3(signature = (bc_bytes, wasm_bytes = None))]
+    #[pyo3(signature = (bc_bytes, *, wasm_bytes = None))]
     pub fn validate_qir(bc_bytes: Cow<[u8]>, wasm_bytes: Option<Cow<[u8]>>) -> PyResult<()> {
         crate::validate_qir_core(&bc_bytes, wasm_bytes.as_deref())
             .map_err(PyErr::new::<ValidationError, _>)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
+use std::fs;
 use std::path::Path;
 use std::process::exit;
-use std::{borrow::Cow::Borrowed, fs};
 
-use pyo3::Python;
-use qir_qis::qir_qis::{get_entry_attributes, qir_ll_to_bc, qir_to_qis, validate_qir};
+use qir_qis::{get_entry_attributes_core, qir_ll_to_bc_core, qir_to_qis_core, validate_qir_core};
 
 use bpaf::Bpaf;
 
@@ -33,16 +32,15 @@ fn main() {
     let ll_path = Path::new(&args.ll_path);
     let ll_text = fs::read_to_string(ll_path).expect("Failed to read input file");
 
-    Python::initialize();
-    let bc_bytes = qir_ll_to_bc(&ll_text).unwrap();
-    if let Err(err) = validate_qir(Borrowed(&bc_bytes), None) {
+    let bc_bytes = qir_ll_to_bc_core(&ll_text).unwrap();
+    if let Err(err) = validate_qir_core(&bc_bytes, None) {
         eprintln!("QIR validation failed: {err:?}");
         exit(1);
     }
 
-    println!("{:#?}", get_entry_attributes(Borrowed(&bc_bytes)));
+    println!("{:#?}", get_entry_attributes_core(&bc_bytes));
 
-    let qis_module = qir_to_qis(bc_bytes, args.opt_level, &args.target, None).unwrap();
+    let qis_module = qir_to_qis_core(&bc_bytes, args.opt_level, &args.target, None).unwrap();
     let qis_path = ll_path.with_extension("qis.bc");
     fs::write(&qis_path, qis_module).expect("Failed to write output file");
 }

--- a/tests/data/base-attrs.ll
+++ b/tests/data/base-attrs.ll
@@ -1,11 +1,15 @@
-; type definitions
+; entry point definition
 
 define i64 @Entry_Point_Name() #0 {
 entry:
   ret i64 0
 }
 
+; attributes
+
 attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_schema"="labeled" "required_num_qubits"="2" "required_num_results"="2" }
+
+; module flags
 
 !llvm.module.flags = !{!0, !1, !2, !3}
 


### PR DESCRIPTION

## Checklist

- [x] Tests pass (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated
- [ ] [CHANGELOG.md](../CHANGELOG.md) updated
- [ ] New tests added (if applicable)
- [x] Python stubs regenerated (if API changed: `make stubs`)
