### PR TITLE
ci: run test suite on Ubuntu, macOS, and Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
+      - name: Test (Windows suite)
+        if: runner.os == 'Windows'
+        run: cargo nextest run --all-targets --all-features --test-threads=1 -E "not test(test_get_entry_attributes)"
+      - name: Test (Windows isolated get_entry_attributes)
+        if: runner.os == 'Windows'
+        run: cargo test --all-targets --all-features test_get_entry_attributes -- --test-threads=1
       - name: Test
+        if: runner.os != 'Windows'
         run: cargo nextest run --all-targets --all-features ${{ matrix.nextest_extra_args }}
 
   lint:


### PR DESCRIPTION
## Summary
- split `test-lint` into separate `test` (matrix) and `lint` (ubuntu) jobs
- run tests on `ubuntu-latest`, `macos-latest`, and `windows-latest` using `cargo nextest`
- add platform-specific LLVM setup for test jobs:
  - Linux via `install-llvm-action`
  - macOS via LLVM 14 tarball + `LLVM_SYS_140_PREFIX`, `DYLD_FALLBACK_LIBRARY_PATH`, and `llvm-as` on `PATH`
  - Windows via PLC LLVM package in `C:\LLVM` + `LLVM_SYS_140_PREFIX`
- improve matrix reliability with `fail-fast: false`
- stabilize Windows tests by running `test_get_entry_attributes` in isolation (separate from the main `nextest` suite)
- keep fmt/clippy/msrv checks in ubuntu `lint`
