### PR TITLE
chore: ignore llvm-sys dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # Keep llvm-sys aligned with inkwell, CI images, and the installed LLVM toolchain.
+      # Standalone bumps create unusable PRs (for example llvm-sys 221 while the repo is on LLVM 21).
+      - dependency-name: "llvm-sys"


### PR DESCRIPTION
## Summary
- ignore standalone Dependabot updates for `llvm-sys`
- document that `llvm-sys` must stay aligned with `inkwell`, CI images, and the pinned LLVM toolchain

## Why
PR #29 shows that direct `llvm-sys` bumps can target an incompatible LLVM major while repo support is being coordinated separately in PR #30.