### PR TITLE
docs: separate maintainer guidance from user docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,13 @@ repos:
     hooks:
       - id: refurb
 
-  - repo: https://github.com/berquist/pre-commit-rust
-    rev: 968f0f2
+  - repo: https://github.com/AndrejOrsula/pre-commit-cargo
+    rev: 0.5.0
     hooks:
       - id: cargo-fmt
-      - id: cargo-check
       - id: cargo-clippy
+        args: ["--all-targets", "--all-features", "--", "-W", "clippy::pedantic", "-W", "clippy::nursery"]
+      - id: cargo-test-doc
+        args: ["--all-features"]
+      - id: cargo-doc
+        args: ["--no-deps", "--document-private-items"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing! We welcome contributions from the c
 
 ## Getting Started
 
-See the [Development section](README.md#development) in the README for setup instructions, testing, and build processes.
+See [DEVELOPMENT.md](DEVELOPMENT.md) for setup instructions, test commands, build processes, and LLVM maintenance guidance. For release notes, see [CHANGELOG.md](CHANGELOG.md).
 
 ## How to Contribute
 
@@ -70,11 +70,7 @@ type(scope): brief description
 
 ## Testing
 
-See [README Testing section](README.md#testing) for details on:
-
-- Running the test suite
-- Testing individual files
-- Simulation testing with Selene
+See [DEVELOPMENT.md](DEVELOPMENT.md) for the current test, fixture compilation, and simulation commands.
 
 Always add tests for new features and ensure all tests pass before submitting a PR.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,16 +11,27 @@ cd qir-qis
 
 # Install LLVM 21 (macOS/Homebrew example)
 brew install llvm@21
-if [ "$(uname -m)" = "arm64" ]; then
-  export LLVM_SYS_211_PREFIX=/opt/homebrew/opt/llvm@21
-else
-  export LLVM_SYS_211_PREFIX=/usr/local/opt/llvm@21
-fi
+```
 
-# Install Rust dependencies and build
+### Configure LLVM Environment
+
+Set `LLVM_SYS_211_PREFIX` before running the build and test commands below. On macOS with Homebrew, `/path/to/llvm21` is typically `/opt/homebrew/opt/llvm@21`. On Linux, it is typically `/usr/lib/llvm-21`.
+
+```sh
+export LLVM_SYS_211_PREFIX=/path/to/llvm21
+```
+
+If you want this to persist across shells, add it to your shell startup file:
+
+```sh
+echo 'export LLVM_SYS_211_PREFIX=/path/to/llvm21' >> ~/.zshrc
+source ~/.zshrc
+```
+
+Then install Rust dependencies and Python dependencies:
+
+```sh
 cargo build
-
-# Install Python dependencies
 uv sync
 ```
 
@@ -28,11 +39,9 @@ uv sync
 
 ```sh
 # Build Rust binary
-LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
 cargo build --release
 
 # Build Python package
-LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
 uv run maturin build --release
 ```
 
@@ -42,11 +51,9 @@ Tests require [cargo-nextest](https://nexte.st/docs/installation/pre-built-binar
 
 ```sh
 # Run all tests
-LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
 make test
 
 # Or directly with the same target as `make test`
-LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
 cargo nextest run --all-targets --all-features
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,9 +81,8 @@ make lint
 
 `make lint` runs:
 
-- `prek` pre-commit checks
-- `ty`
-- `cargo clippy`
+- `prek` checks, including formatting, `typos`, and Rust lint/doc hooks
+- `ty` type checking
 
 ### Python Stubs
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,115 @@
+# Development Notes
+
+## Setup
+
+The default development toolchain is tracked in `rust-toolchain.toml` and follows the stable Rust release. The minimum supported Rust version (MSRV) is tracked separately in `Cargo.toml` and verified in CI. This project currently builds against LLVM 21.
+
+```sh
+# Clone the repository
+git clone https://github.com/quantinuum/qir-qis.git
+cd qir-qis
+
+# Install LLVM 21 (macOS/Homebrew example)
+brew install llvm@21
+if [ "$(uname -m)" = "arm64" ]; then
+  export LLVM_SYS_211_PREFIX=/opt/homebrew/opt/llvm@21
+else
+  export LLVM_SYS_211_PREFIX=/usr/local/opt/llvm@21
+fi
+
+# Install Rust dependencies and build
+cargo build
+
+# Install Python dependencies
+uv sync
+```
+
+## Building
+
+```sh
+# Build Rust binary
+LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
+cargo build --release
+
+# Build Python package
+LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
+uv run maturin build --release
+```
+
+## Testing
+
+Tests require [cargo-nextest](https://nexte.st/docs/installation/pre-built-binaries/).
+
+```sh
+# Run all tests
+LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
+make test
+
+# Or directly with the same target as `make test`
+LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
+cargo nextest run --all-targets --all-features
+```
+
+### QIR Fixtures
+
+```sh
+# Compile a single QIR file
+make compile FILE=tests/data/adaptive.ll
+
+# Compile all test files
+make allcompile
+```
+
+### Simulation
+
+Test the compiled QIS using [Selene quantum simulator](https://docs.quantinuum.com/selene/).
+
+```sh
+# Simulate a single file (runs 5 shots by default)
+make sim FILE=tests/data/adaptive.ll
+
+# Simulate all test files
+make allsim
+```
+
+### Code Quality
+
+```sh
+# Run linters
+make lint
+```
+
+`make lint` runs:
+
+- `prek` pre-commit checks
+- `ty`
+- `cargo clippy`
+
+### Python Stubs
+
+After modifying the Python API:
+
+```sh
+make stubs
+```
+
+This updates `qir_qis.pyi` with the latest type signatures.
+
+## Updating LLVM
+
+For an LLVM bump, update:
+
+1. `Cargo.toml`:
+   - `inkwell` feature, for example `llvm21-1` to the matching new feature
+   - `llvm-sys` crate version, for example `211.0.0` to the matching new version
+2. `.github/actions/setup-llvm/action.yml` for the default LLVM version and versioned `llvm-sys` prefix environment variable.
+3. `.github/workflows/CI.yml` and `.github/workflows/rust-release.yml` for `LLVM_VERSION`, `LLVM_SYS_PREFIX_ENV_VAR`, and related cache-key names.
+4. `pyproject.toml` for the cibuildwheel environment variables and macOS wheel setup commands.
+5. `README.md`, `DEVELOPMENT.md`, and any other docs or comments that mention `llvm@21`, `LLVM_SYS_211_PREFIX`, or LLVM 21 examples.
+
+After the bump, run:
+
+1. `make test`
+2. `cargo run --example rust_api`
+3. `make lint`
+4. the CI matrix and wheel builds

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ compile:
 lint:
 	uvx prek run --all-files
 	uvx ty check
-	cargo clippy --all-targets --all-features -- -W clippy::pedantic -W clippy::nursery
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -55,12 +55,6 @@ uv pip install qir-qis
 pip install qir-qis
 ```
 
-For development installation:
-
-```sh
-uv sync
-```
-
 ## Usage
 
 ### Command Line
@@ -101,136 +95,6 @@ See [examples/rust_api.rs](https://github.com/quantinuum/qir-qis/blob/main/examp
 cargo run --example rust_api
 ```
 
-## Development
-
-### Setting Up Development Environment
-
-```sh
-# Clone the repository
-git clone https://github.com/quantinuum/qir-qis.git
-cd qir-qis
-
-# Install LLVM 21 (macOS/Homebrew example)
-brew install llvm@21
-export LLVM_SYS_211_PREFIX=/opt/homebrew/opt/llvm@21
-
-# Install Rust dependencies and build
-cargo build
-
-# Install Python dependencies
-uv sync
-```
-
-### Building
-
-```sh
-# Build Rust binary
-LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
-cargo build --release
-
-# Build Python package
-LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
-uv run maturin build --release
-```
-
-### Testing
-
-#### Running Tests
-
-Tests require [cargo-nextest](https://nexte.st/docs/installation/pre-built-binaries/):
-
-```sh
-# Run all tests
-LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
-make test
-
-# Or directly with cargo
-LLVM_SYS_211_PREFIX=${LLVM_SYS_211_PREFIX:-/opt/homebrew/opt/llvm@21} \
-cargo nextest run --all-targets --all-features
-```
-
-#### Testing Individual Files
-
-```sh
-# Compile a single QIR file
-make compile FILE=tests/data/adaptive.ll
-
-# Compile all test files
-make allcompile
-```
-
-#### Simulation Testing with Selene
-
-Test the compiled QIS using [Selene quantum simulator](https://docs.quantinuum.com/selene/):
-
-```sh
-# Simulate a single file (runs 5 shots by default)
-make sim FILE=tests/data/adaptive.ll
-
-# Simulate all test files
-make allsim
-```
-
-This will:
-
-1. Compile the QIR to QIS
-2. Run it on the Selene/Quest simulator
-3. Display measurement results
-
-### Code Quality
-
-```sh
-# Run linters
-make lint
-
-# This runs:
-# - prek (pre-commit checks, https://prek.j178.dev/)
-# - typos checker
-# - cargo clippy
-```
-
-### Regenerating Python Stubs
-
-After modifying the Python API:
-
-```sh
-make stubs
-```
-
-This updates [qir_qis.pyi](https://github.com/quantinuum/qir-qis/blob/main/qir_qis.pyi) with the latest type signatures.
-
-## Project Structure
-
-```text
-qir-qis/
-├── src/
-│   ├── main.rs          # CLI entry point
-│   ├── lib.rs           # Library and Python bindings
-│   ├── convert.rs       # QIR to QIS conversion logic
-│   ├── decompose.rs     # Gate decomposition
-│   ├── opt.rs           # LLVM optimization passes
-│   └── utils.rs         # Helper utilities
-├── tests/
-│   ├── data/            # Test QIR files
-│   └── snaps/           # Snapshot test results
-├── main.py              # Example Python usage with simulation
-├── Cargo.toml           # Rust package configuration
-├── pyproject.toml       # Python package configuration
-└── Makefile             # Common development tasks
-```
-
-## Common Makefile Targets
-
-| Command                    | Description                        |
-|----------------------------|------------------------------------|
-| `make test`                | Run all unit and integration tests |
-| `make compile FILE=<path>` | Compile a single QIR file          |
-| `make sim FILE=<path>`     | Compile and simulate a QIR file    |
-| `make lint`                | Run code quality checks            |
-| `make stubs`               | Regenerate Python type stubs       |
-| `make allcompile`          | Compile all test files             |
-| `make allsim`              | Simulate all test files            |
-
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTING.md](https://github.com/quantinuum/qir-qis/blob/main/CONTRIBUTING.md) for:
@@ -239,11 +103,7 @@ Contributions are welcome! Please read [CONTRIBUTING.md](https://github.com/quan
 - Coding standards and commit message format
 - Development workflow and testing requirements
 
-**Quick checklist before submitting:**
-
-- [ ] Tests pass: `make test`
-- [ ] Linters pass: `make lint`
-- [ ] Documentation updated
+Development setup, test commands, and LLVM upgrade guidance live in [DEVELOPMENT.md](https://github.com/quantinuum/qir-qis/blob/main/DEVELOPMENT.md). Release notes are available in [CHANGELOG.md](https://github.com/quantinuum/qir-qis/blob/main/CHANGELOG.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

Move maintainer-oriented setup and workflow guidance out of the README and into DEVELOPMENT.md, and align the local lint/pre-commit workflow with the current maintainer docs.

## Included
- README focused on installation and usage
- CONTRIBUTING points to maintainer workflow docs
- DEVELOPMENT.md for setup, testing, linting, and LLVM maintenance notes, including simplified macOS/Linux LLVM environment guidance
- Replace the Rust pre-commit hook integration with the cargo hook set
- Align `make lint` with the pre-commit Rust hooks to avoid redundant checks
