### PR TITLE
ci: skip heavy checks for docs-only changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,14 @@ on:
     types:
       - opened
       - synchronize
+    paths-ignore:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "DEVELOPMENT.md"
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - "qtm-qir-reference.md"
+      - ".github/*.md"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- ignore docs-only file changes on pull_request events
- let docs PRs avoid the heavy CI matrix

## Testing
- not run (GitHub Actions change only)