### PR TITLE
ci: run typos on docs-only changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,12 +26,6 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
-  typos:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: crate-ci/typos@v1.42.0
-
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,20 @@
+name: Typos
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "*.*.*"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.42.0


### PR DESCRIPTION
## Summary
- move `typos` out of the main CI workflow
- keep Rust test and lint jobs skipped for docs-only pull requests
- run spelling checks on docs-only pull requests via a dedicated workflow

## Why
PR #36 only touches documentation, but the current `pull_request.paths-ignore` on `CI.yml` prevents the `typos` job from running at all.
