### PR TITLE
ci: install LLVM from apt.llvm.org on Ubuntu

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -45,7 +45,11 @@ runs:
         curl -fsSL https://apt.llvm.org/llvm.sh -o "${script_path}"
         chmod +x "${script_path}"
         sudo "${script_path}" "${llvm_major}"
-        sudo apt-get install -y "llvm-${llvm_major}-dev" "clang-${llvm_major}" "lld-${llvm_major}"
+        sudo apt-get install -y \
+          "llvm-${llvm_major}-dev" \
+          "clang-${llvm_major}" \
+          "lld-${llvm_major}" \
+          "libpolly-${llvm_major}-dev"
 
     - name: Configure LLVM (Linux)
       if: runner.os == 'Linux' && inputs.enable-linux == 'true'


### PR DESCRIPTION
Installs LLVM from apt.llvm.org on Linux CI runners instead of using the previous GitHub-action-based setup.

Scope:
- switch only the Linux path in `.github/actions/setup-llvm/action.yml`
- use the official `apt.llvm.org` installer script plus `llvm-<major>-dev`, `clang-<major>`, `lld-<major>`, and `libpolly-<major>-dev`
- leave macOS, Windows, and manylinux wheel Docker images unchanged

Why:
- Ubuntu CI jobs became materially faster with the apt-based install path
- Linux CI still passes with the system package layout

Not included:
- no production code changes
- no manylinux image changes