### PR TITLE
build: simplify local fuzz entry points

### DIFF
--- a/.github/workflows/robustness.yml
+++ b/.github/workflows/robustness.yml
@@ -45,24 +45,32 @@ env:
   LLVM_LINUX_CACHE_KEY_SUFFIX: "robustness-linux-shared-v1"
 
 jobs:
+  fuzz-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.collect.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Collect fuzz targets
+        id: collect
+        run: |
+          targets=$(
+            find fuzz/fuzz_targets -maxdepth 1 -name '*.rs' -print |
+              sort |
+              sed 's#.*/##; s#\.rs$##' |
+              jq -R . |
+              jq -sc .
+          )
+          echo "targets=${targets}" >>"$GITHUB_OUTPUT"
+
   fuzz-smoke:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
+    needs: fuzz-targets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - qir_ll_to_bc
-          - validate_qir
-          - parse_wasm_functions
-          - qir_to_qis
-          - get_entry_attributes
-          - validate_fixture_with_wasm
-          - mutated_fixture_bitcode
-          - mutated_fixture_contracts
-          - declared_qis_calls
-          - entry_contracts
-          - result_index_contracts
+        target: ${{ fromJson(needs.fuzz-targets.outputs.targets) }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup LLVM
@@ -100,22 +108,12 @@ jobs:
 
   fuzz-long:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    needs: fuzz-targets
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - qir_ll_to_bc
-          - validate_qir
-          - parse_wasm_functions
-          - qir_to_qis
-          - get_entry_attributes
-          - validate_fixture_with_wasm
-          - mutated_fixture_bitcode
-          - mutated_fixture_contracts
-          - declared_qis_calls
-          - entry_contracts
-          - result_index_contracts
+        target: ${{ fromJson(needs.fuzz-targets.outputs.targets) }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup LLVM

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ For most semantic changes:
 
 When touching fuzzing or robustness workflows, also run a focused subset such as:
 
-- `make fuzz-check FUZZ_TARGET=<target>`
+- `make fuzz FUZZ_TARGET=<target> FUZZ_RUN_ARGS=-max_total_time=15`
 - `cargo +nightly fuzz check --target $(rustc -vV | sed -n 's/^host: //p') <target>`
 
 When touching mutation coverage or exclusions:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,10 +103,7 @@ The repo also supports three complementary robustness checks:
 # Mutation testing (install cargo-mutants first)
 make mutants
 
-# Build-check a single fuzz target (requires nightly + cargo-fuzz)
-make fuzz-check FUZZ_TARGET=validate_qir
-
-# Run a bounded fuzz target locally
+# Run a bounded fuzz target locally (requires nightly + cargo-fuzz)
 make fuzz FUZZ_TARGET=qir_to_qis FUZZ_RUN_ARGS=-max_total_time=30
 
 # Run all current fuzz targets with short local smoke budgets

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ lint:
 .PHONY: test
 test:
 	cargo nextest run --all-targets --all-features
-	$(PYTHON) tests/test_main.py
 
 .PHONY: mutants
 mutants:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-PYTHON = uv run --no-sync -- python
+PYTHON = uv run -- python
 RUST_HOST_TARGET ?= $(shell rustc -vV | sed -n 's/^host: //p')
 FUZZ_TARGET ?= validate_qir
 FUZZ_RUN_ARGS ?= -max_total_time=30
+FUZZ_ALL_TARGETS := $(basename $(notdir $(wildcard fuzz/fuzz_targets/*.rs)))
 
 .PHONY: compile
 # Usage:
@@ -17,14 +18,11 @@ lint:
 .PHONY: test
 test:
 	cargo nextest run --all-targets --all-features
+	$(PYTHON) tests/test_main.py
 
 .PHONY: mutants
 mutants:
 	cargo mutants --package qir-qis --all-features --test-tool cargo
-
-.PHONY: fuzz-check
-fuzz-check:
-	cargo +nightly fuzz check --target $(RUST_HOST_TARGET) $(FUZZ_TARGET)
 
 .PHONY: fuzz
 fuzz:
@@ -32,7 +30,7 @@ fuzz:
 
 .PHONY: fuzz-all
 fuzz-all:
-	@for target in qir_ll_to_bc validate_qir parse_wasm_functions qir_to_qis get_entry_attributes validate_fixture_with_wasm mutated_fixture_bitcode mutated_fixture_contracts declared_qis_calls entry_contracts result_index_contracts; do \
+	@for target in $(FUZZ_ALL_TARGETS); do \
 		cargo +nightly fuzz check --target $(RUST_HOST_TARGET) "$$target" || exit 1; \
 		cargo +nightly fuzz run --target $(RUST_HOST_TARGET) "$$target" -- -max_total_time=15 || exit 1; \
 	done


### PR DESCRIPTION
## Summary
Simplify the local fuzz workflow and keep robustness CI in sync with the actual `fuzz/fuzz_targets` directory.

## Included
- keep the local entry points to `make fuzz` and `make fuzz-all`
- make `fuzz-all` discover targets from `fuzz/fuzz_targets/*.rs` instead of hard-coding them
- make `robustness.yml` discover the same fuzz target list for its smoke and long-running matrices
- trim the local docs and agent guidance to match the simplified workflow
