### PR TITLE
feat: add mz leaked support

### DIFF
--- a/qtm-qir-reference.md
+++ b/qtm-qir-reference.md
@@ -41,6 +41,7 @@ declare void @__quantum__qis__rz__body(double, %Qubit*)
 declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
 
 declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly)
+declare i64 @__quantum__qis__mz_leaked__body(%Qubit*)
 declare void @__quantum__qis__reset__body(%Qubit*)
 ```
 
@@ -69,6 +70,16 @@ declare void @__quantum__qis__m__body(%Qubit*, %Result* writeonly)
 ; Synonym for __quantum__qis__cx__body
 declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
 ```
+
+`__quantum__qis__mz_leaked__body(%Qubit*)` performs a Z-basis measurement and
+returns an `i64` directly:
+
+- `0` for `|0>`
+- `1` for `|1>`
+- `2` for leaked
+
+Unlike `mz`, it does not consume a `%Result*` slot and can be paired directly
+with `__quantum__rt__int_record_output`.
 
 #### Decompositions
 

--- a/qtm-qir-reference.md
+++ b/qtm-qir-reference.md
@@ -41,7 +41,6 @@ declare void @__quantum__qis__rz__body(double, %Qubit*)
 declare void @__quantum__qis__rzz__body(double, %Qubit*, %Qubit*)
 
 declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly)
-declare i64 @__quantum__qis__mz_leaked__body(%Qubit*)
 declare void @__quantum__qis__reset__body(%Qubit*)
 ```
 
@@ -70,16 +69,6 @@ declare void @__quantum__qis__m__body(%Qubit*, %Result* writeonly)
 ; Synonym for __quantum__qis__cx__body
 declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
 ```
-
-`__quantum__qis__mz_leaked__body(%Qubit*)` performs a Z-basis measurement and
-returns an `i64` directly:
-
-- `0` for `|0>`
-- `1` for `|1>`
-- `2` for leaked
-
-Unlike `mz`, it does not consume a `%Result*` slot and can be paired directly
-with `__quantum__rt__int_record_output`.
 
 #### Decompositions
 
@@ -145,6 +134,22 @@ rxy(π, -π/4, %control1);
 rz(-3π/4, %control2);
 rz(π/4, %control1);
 ```
+
+### Leaked Measurement
+
+```llvm
+declare i64 @__quantum__qis__mz_leaked__body(%Qubit*)
+```
+
+`__quantum__qis__mz_leaked__body(%Qubit*)` performs a Z-basis measurement and
+returns an `i64` directly:
+
+- `0` for `|0>`
+- `1` for `|1>`
+- `2` for leaked
+
+Unlike `mz`, it does not consume a `%Result*` slot and can be paired directly
+with `__quantum__rt__int_record_output`.
 
 ### Barrier Instructions
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -2228,6 +2228,7 @@ entry:
             #[case("tests/data/base_array.ll")]
             #[case("tests/data/barrier.ll")]
             #[case("tests/data/barrier_multi.ll")]
+            #[case("tests/data/mz_leaked.ll")]
             // Adaptive profile tests
             #[case("tests/data/adaptive.ll")]
             #[case("tests/data/adaptive_ir_fns.ll")]

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -537,6 +537,22 @@ fn build_load_qbit<'a>(
 /// Retrieves the result SSA variables from the entry function.
 /// The result variable count is equal to the `required_num_results` attribute.
 ///
+/// # Errors
+/// Returns an error if the `required_num_results` attribute is missing or invalid.
+pub fn get_required_num_results(entry_fn: FunctionValue) -> Result<usize, String> {
+    entry_fn
+        .get_string_attribute(AttributeLoc::Function, "required_num_results")
+        .and_then(|attr| {
+            decode_llvm_c_string(attr.get_string_value())?
+                .parse::<usize>()
+                .ok()
+        })
+        .ok_or_else(|| "Missing required_num_results".to_string())
+}
+
+/// Retrieves the result SSA variables from the entry function.
+/// The result variable count is equal to the `required_num_results` attribute.
+///
 /// # Returns
 /// a vector of `Option<(BasicValueEnum, Option<BasicValueEnum>)>`.
 /// Each element in the vector corresponds to a result variable, where:
@@ -550,16 +566,8 @@ fn build_load_qbit<'a>(
 pub fn get_result_vars(
     entry_fn: FunctionValue,
 ) -> Result<Vec<Option<(BasicValueEnum, Option<BasicValueEnum>)>>, String> {
-    let num_results = entry_fn
-        .get_string_attribute(AttributeLoc::Function, "required_num_results")
-        .and_then(|attr| {
-            decode_llvm_c_string(attr.get_string_value())?
-                .parse::<u32>()
-                .ok()
-        })
-        .ok_or("Missing required_num_results")?;
-
-    Ok(vec![None; num_results as usize])
+    let num_results = get_required_num_results(entry_fn)?;
+    Ok(vec![None; num_results])
 }
 
 /// Frees all qubits in the qubit array.

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -534,20 +534,26 @@ fn build_load_qbit<'a>(
         .map_err(|e| format!("Failed to build load instruction: {e}"))
 }
 
-/// Retrieves the result SSA variables from the entry function.
-/// The result variable count is equal to the `required_num_results` attribute.
+/// Parses and returns the `required_num_results` attribute from the entry function.
 ///
 /// # Errors
 /// Returns an error if the `required_num_results` attribute is missing or invalid.
 pub fn get_required_num_results(entry_fn: FunctionValue) -> Result<usize, String> {
-    entry_fn
+    let attr = entry_fn
         .get_string_attribute(AttributeLoc::Function, "required_num_results")
-        .and_then(|attr| {
-            decode_llvm_c_string(attr.get_string_value())?
-                .parse::<usize>()
-                .ok()
-        })
-        .ok_or_else(|| "Missing required_num_results".to_string())
+        .ok_or_else(|| "Missing required_num_results".to_string())?;
+
+    let raw_value = attr.get_string_value();
+    let decoded_value = decode_llvm_c_string(raw_value).ok_or_else(|| {
+        format!(
+            "Invalid required_num_results attribute value: {:?}",
+            attr.get_string_value()
+        )
+    })?;
+
+    decoded_value
+        .parse::<usize>()
+        .map_err(|_| format!("Invalid required_num_results attribute value: {decoded_value}"))
 }
 
 /// Retrieves the result SSA variables from the entry function.
@@ -1372,6 +1378,23 @@ mod tests {
         let result = get_result_vars(func);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Missing required_num_results");
+    }
+
+    #[test]
+    fn test_get_required_num_results_errors_on_invalid_attr() {
+        let context = Context::create();
+        let module = context.create_module("test");
+        let fn_type = context.void_type().fn_type(&[], false);
+        let func = module.add_function("entry", fn_type, None);
+        let attr = context.create_string_attribute("required_num_results", "abc");
+        func.add_attribute(AttributeLoc::Function, attr);
+
+        let result = get_required_num_results(func);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "Invalid required_num_results attribute value: abc"
+        );
     }
 
     #[test]

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -551,9 +551,11 @@ pub fn get_required_num_results(entry_fn: FunctionValue) -> Result<usize, String
         )
     })?;
 
-    decoded_value
-        .parse::<usize>()
-        .map_err(|_| format!("Invalid required_num_results attribute value: {decoded_value}"))
+    let required_num_results = decoded_value
+        .parse::<u32>()
+        .map_err(|_| format!("Invalid required_num_results attribute value: {decoded_value}"))?;
+
+    Ok(required_num_results as usize)
 }
 
 /// Retrieves the result SSA variables from the entry function.
@@ -1394,6 +1396,23 @@ mod tests {
         assert_eq!(
             result.unwrap_err(),
             "Invalid required_num_results attribute value: abc"
+        );
+    }
+
+    #[test]
+    fn test_get_required_num_results_errors_on_out_of_range_attr() {
+        let context = Context::create();
+        let module = context.create_module("test");
+        let fn_type = context.void_type().fn_type(&[], false);
+        let func = module.add_function("entry", fn_type, None);
+        let attr = context.create_string_attribute("required_num_results", "4294967296");
+        func.add_attribute(AttributeLoc::Function, attr);
+
+        let result = get_required_num_results(func);
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "Invalid required_num_results attribute value: 4294967296"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,9 +248,12 @@ mod aux {
     }
 
     pub fn validate_result_slot_usage(entry_fn: FunctionValue, errors: &mut Vec<String>) {
-        let Ok(required_num_results) = get_required_num_results(entry_fn) else {
-            errors.push("Missing required_num_results".to_string());
-            return;
+        let required_num_results = match get_required_num_results(entry_fn) {
+            Ok(required_num_results) => required_num_results,
+            Err(err) => {
+                errors.push(err);
+                return;
+            }
         };
 
         for bb in entry_fn.get_basic_blocks() {
@@ -759,7 +762,20 @@ mod aux {
         builder.position_before(instr);
 
         let call_args: Vec<BasicValueEnum> = extract_operands(instr)?;
-        let qubit_ptr = call_args[0].into_pointer_value();
+        let qubit_ptr = match call_args.as_slice() {
+            [BasicValueEnum::PointerValue(ptr), _] => *ptr,
+            [_, _] => {
+                return Err(
+                    "Malformed mz_leaked call: expected first argument to be a pointer".into(),
+                );
+            }
+            _ => {
+                return Err(format!(
+                    "Malformed mz_leaked call: expected 1 argument plus callee, got {} operands",
+                    call_args.len()
+                ));
+            }
+        };
 
         let q_handle = {
             let idx_fn = module
@@ -2702,6 +2718,16 @@ declare void @__quantum__rt__int_record_output(i64, i8*)
     }
 
     #[test]
+    fn test_validate_qir_reports_invalid_required_num_results_value() {
+        let ll_text = minimal_qir_with_body("1", "abc", "1", "", "");
+
+        let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = validate_qir(&bc_bytes, None)
+            .expect_err("invalid required_num_results should fail validation");
+        assert!(err.contains("Invalid required_num_results attribute value: abc"));
+    }
+
+    #[test]
     fn test_validate_qir_rejects_zero_required_num_results_for_result_measurement() {
         let ll_text = minimal_qir_with_body(
             "1",
@@ -2767,6 +2793,22 @@ declare void @__quantum__rt__result_record_output(%Result*, i8*)
         let err = validate_qir(&bc_bytes, None)
             .expect_err("out-of-bounds result indices should fail during validation");
         assert!(err.contains("Result index 5 exceeds required_num_results (1)"));
+    }
+
+    #[test]
+    fn test_qir_to_qis_rejects_malformed_mz_leaked_call() {
+        let ll_text = minimal_qir_with_body(
+            "1",
+            "0",
+            "1",
+            "declare i64 @__quantum__qis__mz_leaked__body()",
+            r"  %0 = call i64 @__quantum__qis__mz_leaked__body()",
+        );
+
+        let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = qir_to_qis(&bc_bytes, 0, "native", None)
+            .expect_err("malformed mz_leaked calls should fail cleanly");
+        assert!(err.contains("Malformed mz_leaked call"));
     }
 
     #[cfg(not(windows))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,12 +87,13 @@ mod aux {
         },
     };
 
-    static ALLOWED_QIS_FNS: [&str; 22] = [
+    static ALLOWED_QIS_FNS: [&str; 23] = [
         // Native gates
         "__quantum__qis__rxy__body",
         "__quantum__qis__rz__body",
         "__quantum__qis__rzz__body",
         "__quantum__qis__mz__body",
+        "__quantum__qis__mz_leaked__body",
         "__quantum__qis__reset__body",
         // mz + reset
         "__quantum__qis__mresetz__body",
@@ -523,6 +524,9 @@ mod aux {
             | "__quantum__qis__mresetz__body" => {
                 handle_mz_call(args)?;
             }
+            "__quantum__qis__mz_leaked__body" => {
+                handle_mz_leaked_call(args)?;
+            }
             "__quantum__qis__reset__body" => {
                 handle_reset_call(args)?;
             }
@@ -679,6 +683,92 @@ mod aux {
         }
 
         // Remove original call
+        instr.erase_from_basic_block();
+        Ok(())
+    }
+
+    fn handle_mz_leaked_call(args: &ProcessCallArgs) -> Result<(), String> {
+        let ProcessCallArgs {
+            ctx,
+            module,
+            instr,
+            qubit_array,
+            qubit_array_type,
+            ..
+        } = args;
+        let builder = ctx.create_builder();
+        builder.position_before(instr);
+
+        let call_args: Vec<BasicValueEnum> = extract_operands(instr)?;
+        let qubit_ptr = call_args[0].into_pointer_value();
+
+        let q_handle = {
+            let i64_type = ctx.i64_type();
+            let index = get_index(qubit_ptr)?;
+            let index_val = i64_type.const_int(index, false);
+            let elem_ptr = unsafe {
+                builder.build_gep(
+                    *qubit_array_type,
+                    *qubit_array,
+                    &[i64_type.const_zero(), index_val],
+                    "",
+                )
+            }
+            .map_err(|e| format!("Failed to build GEP for qubit handle: {e}"))?;
+            builder
+                .build_load(i64_type, elem_ptr, "qbit")
+                .map_err(|e| format!("Failed to build load for qubit handle: {e}"))?
+        };
+
+        let meas_handle = {
+            let meas_func = get_or_create_function(
+                module,
+                "___lazy_measure_leaked",
+                ctx.i64_type().fn_type(&[ctx.i64_type().into()], false),
+            );
+
+            let call = builder.build_call(meas_func, &[q_handle.into()], "meas_leaked");
+            let call_result = call.map_err(|e| {
+                format!("Failed to build call for lazy leaked measure function: {e}")
+            })?;
+            match call_result.try_as_basic_value() {
+                inkwell::values::ValueKind::Basic(bv) => bv,
+                inkwell::values::ValueKind::Instruction(_) => {
+                    return Err("Failed to get basic value from lazy leaked measure call".into());
+                }
+            }
+        };
+
+        let meas_value = {
+            let read_func = get_or_create_function(
+                module,
+                "___read_future_uint",
+                ctx.i64_type().fn_type(&[ctx.i64_type().into()], false),
+            );
+            let call = builder.build_call(read_func, &[meas_handle.into()], "meas_leaked_value");
+            let call_result =
+                call.map_err(|e| format!("Failed to build call for read_future_uint: {e}"))?;
+            match call_result.try_as_basic_value() {
+                inkwell::values::ValueKind::Basic(bv) => bv,
+                inkwell::values::ValueKind::Instruction(_) => {
+                    return Err("Failed to get basic value from read_future_uint call".into());
+                }
+            }
+        };
+
+        let dec_func = get_or_create_function(
+            module,
+            "___dec_future_refcount",
+            ctx.void_type().fn_type(&[ctx.i64_type().into()], false),
+        );
+        let _ = builder
+            .build_call(dec_func, &[meas_handle.into()], "")
+            .map_err(|e| format!("Failed to build call for dec_future_refcount: {e}"))?;
+
+        let instruction_val = meas_value
+            .as_instruction_value()
+            .ok_or("Failed to convert leaked measurement value to instruction value")?;
+        instr.replace_all_uses_with(&instruction_val);
         instr.erase_from_basic_block();
         Ok(())
     }
@@ -1431,11 +1521,10 @@ pub fn validate_qir(bc_bytes: &[u8], wasm_bytes: Option<&[u8]>) -> Result<(), St
             }
         }
 
-        // Check values for non-zero qubits/results
-        for (attr, type_) in [
-            ("required_num_qubits", "qubit"),
-            ("required_num_results", "result"),
-        ] {
+        // `required_num_qubits` must stay positive. `required_num_results`
+        // may be zero for programs that only use classical-returning operations
+        // such as `mz_leaked`.
+        for (attr, type_) in [("required_num_qubits", "qubit")] {
             if entry_fn
                 .get_string_attribute(AttributeLoc::Function, attr)
                 .and_then(|a| {
@@ -1703,6 +1792,7 @@ mod test {
         "tests/data/adaptive.ll",
         "tests/data/qir2_base.ll",
         "tests/data/qir2_adaptive.ll",
+        "tests/data/mz_leaked.ll",
     ];
     static PROPERTY_FIXTURE_BITCODE: LazyLock<BTreeMap<&'static str, Vec<u8>>> =
         LazyLock::new(|| {
@@ -2527,6 +2617,63 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
         assert_eq!(err, "Result index 5 exceeds required_num_results (1)");
     }
 
+    #[test]
+    fn test_validate_qir_allows_zero_required_num_results_for_mz_leaked() {
+        let ll_text = minimal_qir_with_body(
+            "1",
+            "0",
+            "1",
+            r#"
+declare i64 @__quantum__qis__mz_leaked__body(%Qubit*)
+declare void @__quantum__rt__int_record_output(i64, i8*)
+
+@0 = private constant [7 x i8] c"leaked\00"
+"#,
+            r"  %q0 = inttoptr i64 0 to %Qubit*
+  %0 = call i64 @__quantum__qis__mz_leaked__body(%Qubit* %q0)
+  call void @__quantum__rt__int_record_output(i64 %0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @0, i64 0, i64 0))",
+        );
+
+        let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
+        validate_qir(&bc_bytes, None)
+            .expect("mz_leaked-only programs should validate with zero result slots");
+    }
+
+    #[test]
+    fn test_qir_to_qis_rejects_zero_required_num_results_for_result_measurement() {
+        let ll_text = minimal_qir_with_body(
+            "1",
+            "0",
+            "1",
+            "declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly)",
+            r"  call void @__quantum__qis__mz__body(%Qubit* null, %Result* writeonly null)",
+        );
+
+        let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = qir_to_qis(&bc_bytes, 0, "native", None)
+            .expect_err("result-backed measurements should still require declared result slots");
+        assert!(err.contains("Result index 0 exceeds required_num_results (0)"));
+    }
+
+    #[test]
+    fn test_qir_to_qis_mz_leaked_lowers_via_uint_future_runtime() {
+        let bc_bytes = load_fixture_bitcode("tests/data/mz_leaked.ll");
+        let output_bc = qir_to_qis(&bc_bytes, 0, "native", None)
+            .expect("mz_leaked fixture should compile successfully");
+
+        verify_bitcode_module(&output_bc, "mz_leaked_qis")
+            .expect("translated leaked-measure module should remain LLVM-verifiable");
+
+        let ctx = Context::create();
+        let module = parse_bitcode_module(&ctx, &output_bc, "mz_leaked_qis")
+            .expect("Compiled QIS bitcode should parse");
+        let text = module.to_string();
+        assert!(text.contains("___lazy_measure_leaked"));
+        assert!(text.contains("___read_future_uint"));
+        assert!(text.contains("___dec_future_refcount"));
+        assert!(!text.contains("___read_future_bool"));
+    }
+
     #[cfg(feature = "wasm")]
     proptest! {
         #[test]
@@ -2613,19 +2760,6 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
                 .expect_err("validation should reject missing required attributes");
             let expected = format!("Missing required attribute: `{missing_attr}`");
             prop_assert!(err.contains(&expected));
-        }
-
-        #[test]
-        fn prop_zero_qubits_or_results_fail_validation(
-            zero_qubits in any::<bool>()
-        ) {
-            let (qubits, results) = if zero_qubits { ("0", "1") } else { ("1", "0") };
-            let ll_text = minimal_qir_with_body(qubits, results, "1", "", "");
-            let bc = qir_ll_to_bc(&ll_text)
-                .map_err(|err| TestCaseError::fail(format!("inline IR should parse: {err}")))?;
-            let err = validate_qir(&bc, None)
-                .expect_err("validation should reject zero resources");
-            prop_assert!(err.contains("Entry function must have at least one"));
         }
 
         #[test]
@@ -2731,5 +2865,13 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
             bytes.extend(tail);
             prop_assert!(get_entry_attributes(&bytes).is_err());
         }
+    }
+
+    #[test]
+    fn test_zero_qubits_fail_validation() {
+        let ll_text = minimal_qir_with_body("0", "1", "1", "", "");
+        let bc = qir_ll_to_bc(&ll_text).expect("inline IR should parse");
+        let err = validate_qir(&bc, None).expect_err("validation should reject zero qubits");
+        assert!(err.contains("Entry function must have at least one qubit"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -753,12 +753,7 @@ mod aux {
 
     fn handle_mz_leaked_call(args: &ProcessCallArgs) -> Result<(), String> {
         let ProcessCallArgs {
-            ctx,
-            module,
-            instr,
-            qubit_array,
-            qubit_array_type,
-            ..
+            ctx, module, instr, ..
         } = args;
         let builder = ctx.create_builder();
         builder.position_before(instr);
@@ -767,21 +762,20 @@ mod aux {
         let qubit_ptr = call_args[0].into_pointer_value();
 
         let q_handle = {
-            let i64_type = ctx.i64_type();
-            let index = get_index(qubit_ptr)?;
-            let index_val = i64_type.const_int(index, false);
-            let elem_ptr = unsafe {
-                builder.build_gep(
-                    *qubit_array_type,
-                    *qubit_array,
-                    &[i64_type.const_zero(), index_val],
-                    "",
-                )
+            let idx_fn = module
+                .get_function(LOAD_QUBIT_FN)
+                .ok_or_else(|| format!("{LOAD_QUBIT_FN} not found"))?;
+            let idx_call = builder
+                .build_call(idx_fn, &[qubit_ptr.into()], "qbit")
+                .map_err(|e| format!("Failed to build call to {LOAD_QUBIT_FN}: {e}"))?;
+            match idx_call.try_as_basic_value() {
+                inkwell::values::ValueKind::Basic(bv) => bv,
+                inkwell::values::ValueKind::Instruction(_) => {
+                    return Err(format!(
+                        "Failed to get basic value from {LOAD_QUBIT_FN} call"
+                    ));
+                }
             }
-            .map_err(|e| format!("Failed to build GEP for qubit handle: {e}"))?;
-            builder
-                .build_load(i64_type, elem_ptr, "qbit")
-                .map_err(|e| format!("Failed to build load for qubit handle: {e}"))?
         };
 
         let meas_handle = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -769,6 +769,21 @@ mod aux {
         } = args;
         let builder = ctx.create_builder();
         builder.position_before(instr);
+        let call = CallSiteValue::try_from(*args.instr)
+            .map_err(|()| "Malformed mz_leaked call: instruction is not a call site".to_string())?;
+        let called_fn = call
+            .get_called_fn_value()
+            .ok_or_else(|| "Malformed mz_leaked call: missing callee".to_string())?;
+        let fn_type = called_fn.get_type();
+        let param_types = fn_type.get_param_types();
+        let has_expected_signature = fn_type
+            .get_return_type()
+            .is_some_and(|ty| ty.is_int_type() && ty.into_int_type().get_bit_width() == 64)
+            && param_types.len() == 1
+            && param_types[0].is_pointer_type();
+        if !has_expected_signature {
+            return Err("Malformed mz_leaked call: expected signature i64 (ptr)".to_string());
+        }
 
         let call_args: Vec<BasicValueEnum> = extract_operands(instr)?;
         let qubit_ptr = match call_args.as_slice() {
@@ -2854,6 +2869,22 @@ declare void @__quantum__rt__result_record_output(%Result*, i8*)
         let err = qir_to_qis(&bc_bytes, 0, "native", None)
             .expect_err("malformed mz_leaked calls should fail cleanly");
         assert!(err.contains("Malformed mz_leaked call"));
+    }
+
+    #[test]
+    fn test_qir_to_qis_rejects_mz_leaked_with_wrong_return_type() {
+        let ll_text = minimal_qir_with_body(
+            "1",
+            "0",
+            "1",
+            "declare void @__quantum__qis__mz_leaked__body(%Qubit*)",
+            r"  call void @__quantum__qis__mz_leaked__body(%Qubit* null)",
+        );
+
+        let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = qir_to_qis(&bc_bytes, 0, "native", None)
+            .expect_err("mz_leaked with the wrong signature should fail cleanly");
+        assert!(err.contains("Malformed mz_leaked call: expected signature i64 (ptr)"));
     }
 
     #[cfg(not(windows))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,9 @@ mod aux {
         convert::{
             INIT_QARRAY_FN, LOAD_QUBIT_FN, add_print_call, build_result_global, convert_globals,
             create_reset_call, get_index, get_or_create_function, get_required_num_qubits,
-            get_required_num_qubits_strict, get_result_vars, get_string_label,
-            handle_tuple_or_array_output, parse_gep, record_classical_output, replace_rxy_call,
-            replace_rz_call, replace_rzz_call,
+            get_required_num_qubits_strict, get_required_num_results, get_result_vars,
+            get_string_label, handle_tuple_or_array_output, parse_gep, record_classical_output,
+            replace_rxy_call, replace_rz_call, replace_rzz_call,
         },
         decode_llvm_bytes,
         utils::extract_operands,
@@ -244,6 +244,70 @@ mod aux {
             log::debug!(
                 "External function `{fn_name}` found, leaving as-is for downstream processing"
             );
+        }
+    }
+
+    pub fn validate_result_slot_usage(entry_fn: FunctionValue, errors: &mut Vec<String>) {
+        let Ok(required_num_results) = get_required_num_results(entry_fn) else {
+            errors.push("Missing required_num_results".to_string());
+            return;
+        };
+
+        for bb in entry_fn.get_basic_blocks() {
+            for instr in bb.get_instructions() {
+                let Ok(call) = CallSiteValue::try_from(instr) else {
+                    continue;
+                };
+                let Some(fn_name) = call.get_called_fn_value().and_then(|f| {
+                    f.as_global_value()
+                        .get_name()
+                        .to_str()
+                        .ok()
+                        .map(ToOwned::to_owned)
+                }) else {
+                    continue;
+                };
+
+                let result_operand_index = match fn_name.as_str() {
+                    "__quantum__qis__mz__body"
+                    | "__quantum__qis__m__body"
+                    | "__quantum__qis__mresetz__body" => 1,
+                    "__quantum__rt__read_result" | "__quantum__rt__result_record_output" => 0,
+                    _ => continue,
+                };
+
+                let call_args = match extract_operands(&instr) {
+                    Ok(args) => args,
+                    Err(err) => {
+                        errors.push(format!("Failed to inspect `{fn_name}` call: {err}"));
+                        continue;
+                    }
+                };
+                let Some(result_arg) = call_args.get(result_operand_index).copied() else {
+                    errors.push(format!("Call to `{fn_name}` is missing a result operand"));
+                    continue;
+                };
+
+                let BasicValueEnum::PointerValue(result_ptr) = result_arg else {
+                    errors.push(format!(
+                        "Call to `{fn_name}` has a non-pointer result operand"
+                    ));
+                    continue;
+                };
+
+                let result_idx = match get_index(result_ptr) {
+                    Ok(idx) => idx,
+                    Err(err) => {
+                        errors.push(format!(
+                            "Failed to inspect result operand for `{fn_name}`: {err}"
+                        ));
+                        continue;
+                    }
+                };
+                if let Err(err) = checked_result_index(result_idx, required_num_results) {
+                    errors.push(err);
+                }
+            }
         }
     }
 
@@ -1493,7 +1557,10 @@ fn get_wasm_functions(
 /// Returns an error string if validation fails.
 pub fn validate_qir(bc_bytes: &[u8], wasm_bytes: Option<&[u8]>) -> Result<(), String> {
     use crate::{
-        aux::{validate_functions, validate_module_flags, validate_module_layout_and_triple},
+        aux::{
+            validate_functions, validate_module_flags, validate_module_layout_and_triple,
+            validate_result_slot_usage,
+        },
         convert::{ENTRY_ATTRIBUTE_KEYS, find_entry_function},
     };
     use inkwell::{attributes::AttributeLoc, context::Context};
@@ -1546,6 +1613,7 @@ pub fn validate_qir(bc_bytes: &[u8], wasm_bytes: Option<&[u8]>) -> Result<(), St
     let wasm_fns = get_wasm_functions(wasm_bytes)?;
 
     validate_functions(&module, entry_fn, &wasm_fns, &mut errors);
+    validate_result_slot_usage(entry_fn, &mut errors);
 
     validate_module_flags(&module, &mut errors);
 
@@ -2640,7 +2708,7 @@ declare void @__quantum__rt__int_record_output(i64, i8*)
     }
 
     #[test]
-    fn test_qir_to_qis_rejects_zero_required_num_results_for_result_measurement() {
+    fn test_validate_qir_rejects_zero_required_num_results_for_result_measurement() {
         let ll_text = minimal_qir_with_body(
             "1",
             "0",
@@ -2650,9 +2718,61 @@ declare void @__quantum__rt__int_record_output(i64, i8*)
         );
 
         let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
-        let err = qir_to_qis(&bc_bytes, 0, "native", None)
-            .expect_err("result-backed measurements should still require declared result slots");
+        let err = validate_qir(&bc_bytes, None)
+            .expect_err("result-backed measurements should fail validation without result slots");
         assert!(err.contains("Result index 0 exceeds required_num_results (0)"));
+    }
+
+    #[test]
+    fn test_validate_qir_rejects_zero_required_num_results_for_read_result() {
+        let ll_text = minimal_qir_with_body(
+            "1",
+            "0",
+            "1",
+            "declare i1 @__quantum__rt__read_result(%Result*)",
+            r"  %0 = call i1 @__quantum__rt__read_result(%Result* null)",
+        );
+
+        let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = validate_qir(&bc_bytes, None)
+            .expect_err("result reads should fail validation without result slots");
+        assert!(err.contains("Result index 0 exceeds required_num_results (0)"));
+    }
+
+    #[test]
+    fn test_validate_qir_rejects_zero_required_num_results_for_result_record_output() {
+        let ll_text = minimal_qir_with_body(
+            "1",
+            "0",
+            "1",
+            r#"
+declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+@0 = private constant [4 x i8] c"res\00"
+"#,
+            r"  call void @__quantum__rt__result_record_output(%Result* null, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @0, i64 0, i64 0))",
+        );
+
+        let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = validate_qir(&bc_bytes, None)
+            .expect_err("result output should fail validation without result slots");
+        assert!(err.contains("Result index 0 exceeds required_num_results (0)"));
+    }
+
+    #[test]
+    fn test_validate_qir_rejects_out_of_bounds_result_measurement_index() {
+        let ll_text = minimal_qir_with_body(
+            "1",
+            "1",
+            "1",
+            "declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly)",
+            r"  call void @__quantum__qis__mz__body(%Qubit* null, %Result* writeonly inttoptr (i64 5 to %Result*))",
+        );
+
+        let bc_bytes = qir_ll_to_bc(&ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = validate_qir(&bc_bytes, None)
+            .expect_err("out-of-bounds result indices should fail during validation");
+        assert!(err.contains("Result index 5 exceeds required_num_results (1)"));
     }
 
     #[cfg(not(windows))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,13 @@ mod aux {
         entry_fn: FunctionValue,
         errors: &mut Vec<String>,
     ) {
+        if entry_fn
+            .get_string_attribute(AttributeLoc::Function, "required_num_results")
+            .is_none()
+        {
+            return;
+        }
+
         let required_num_results = match get_required_num_results(entry_fn) {
             Ok(required_num_results) => required_num_results,
             Err(err) => {
@@ -2749,6 +2756,31 @@ declare void @__quantum__rt__int_record_output(i64, i8*)
         let err = validate_qir(&bc_bytes, None)
             .expect_err("invalid required_num_results should fail validation");
         assert!(err.contains("Invalid required_num_results attribute value: abc"));
+    }
+
+    #[test]
+    fn test_validate_qir_reports_missing_required_num_results_once() {
+        let ll_text = r#"
+%Qubit = type opaque
+
+define i64 @Entry_Point_Name() #0 {
+entry:
+  ret i64 0
+}
+
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_schema"="schema_id" "required_num_qubits"="1" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+"#;
+
+        let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err =
+            validate_qir(&bc_bytes, None).expect_err("missing required_num_results should fail");
+        assert_eq!(err, "Missing required attribute: `required_num_results`");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,11 @@ mod aux {
         }
     }
 
-    pub fn validate_result_slot_usage(entry_fn: FunctionValue, errors: &mut Vec<String>) {
+    pub fn validate_result_slot_usage(
+        module: &Module,
+        entry_fn: FunctionValue,
+        errors: &mut Vec<String>,
+    ) {
         let required_num_results = match get_required_num_results(entry_fn) {
             Ok(required_num_results) => required_num_results,
             Err(err) => {
@@ -256,59 +260,64 @@ mod aux {
             }
         };
 
-        for bb in entry_fn.get_basic_blocks() {
-            for instr in bb.get_instructions() {
-                let Ok(call) = CallSiteValue::try_from(instr) else {
-                    continue;
-                };
-                let Some(fn_name) = call.get_called_fn_value().and_then(|f| {
-                    f.as_global_value()
-                        .get_name()
-                        .to_str()
-                        .ok()
-                        .map(ToOwned::to_owned)
-                }) else {
-                    continue;
-                };
-
-                let result_operand_index = match fn_name.as_str() {
-                    "__quantum__qis__mz__body"
-                    | "__quantum__qis__m__body"
-                    | "__quantum__qis__mresetz__body" => 1,
-                    "__quantum__rt__read_result" | "__quantum__rt__result_record_output" => 0,
-                    _ => continue,
-                };
-
-                let call_args = match extract_operands(&instr) {
-                    Ok(args) => args,
-                    Err(err) => {
-                        errors.push(format!("Failed to inspect `{fn_name}` call: {err}"));
+        for function in module
+            .get_functions()
+            .filter(|f| f.count_basic_blocks() > 0)
+        {
+            for bb in function.get_basic_blocks() {
+                for instr in bb.get_instructions() {
+                    let Ok(call) = CallSiteValue::try_from(instr) else {
                         continue;
-                    }
-                };
-                let Some(result_arg) = call_args.get(result_operand_index).copied() else {
-                    errors.push(format!("Call to `{fn_name}` is missing a result operand"));
-                    continue;
-                };
+                    };
+                    let Some(fn_name) = call.get_called_fn_value().and_then(|f| {
+                        f.as_global_value()
+                            .get_name()
+                            .to_str()
+                            .ok()
+                            .map(ToOwned::to_owned)
+                    }) else {
+                        continue;
+                    };
 
-                let BasicValueEnum::PointerValue(result_ptr) = result_arg else {
-                    errors.push(format!(
-                        "Call to `{fn_name}` has a non-pointer result operand"
-                    ));
-                    continue;
-                };
+                    let result_operand_index = match fn_name.as_str() {
+                        "__quantum__qis__mz__body"
+                        | "__quantum__qis__m__body"
+                        | "__quantum__qis__mresetz__body" => 1,
+                        "__quantum__rt__read_result" | "__quantum__rt__result_record_output" => 0,
+                        _ => continue,
+                    };
 
-                let result_idx = match get_index(result_ptr) {
-                    Ok(idx) => idx,
-                    Err(err) => {
+                    let call_args = match extract_operands(&instr) {
+                        Ok(args) => args,
+                        Err(err) => {
+                            errors.push(format!("Failed to inspect `{fn_name}` call: {err}"));
+                            continue;
+                        }
+                    };
+                    let Some(result_arg) = call_args.get(result_operand_index).copied() else {
+                        errors.push(format!("Call to `{fn_name}` is missing a result operand"));
+                        continue;
+                    };
+
+                    let BasicValueEnum::PointerValue(result_ptr) = result_arg else {
                         errors.push(format!(
-                            "Failed to inspect result operand for `{fn_name}`: {err}"
+                            "Call to `{fn_name}` has a non-pointer result operand"
                         ));
                         continue;
+                    };
+
+                    let result_idx = match get_index(result_ptr) {
+                        Ok(idx) => idx,
+                        Err(err) => {
+                            errors.push(format!(
+                                "Failed to inspect result operand for `{fn_name}`: {err}"
+                            ));
+                            continue;
+                        }
+                    };
+                    if let Err(err) = checked_result_index(result_idx, required_num_results) {
+                        errors.push(err);
                     }
-                };
-                if let Err(err) = checked_result_index(result_idx, required_num_results) {
-                    errors.push(err);
                 }
             }
         }
@@ -1623,7 +1632,7 @@ pub fn validate_qir(bc_bytes: &[u8], wasm_bytes: Option<&[u8]>) -> Result<(), St
     let wasm_fns = get_wasm_functions(wasm_bytes)?;
 
     validate_functions(&module, entry_fn, &wasm_fns, &mut errors);
-    validate_result_slot_usage(entry_fn, &mut errors);
+    validate_result_slot_usage(&module, entry_fn, &mut errors);
 
     validate_module_flags(&module, &mut errors);
 
@@ -2725,6 +2734,42 @@ declare void @__quantum__rt__int_record_output(i64, i8*)
         let err = validate_qir(&bc_bytes, None)
             .expect_err("invalid required_num_results should fail validation");
         assert!(err.contains("Invalid required_num_results attribute value: abc"));
+    }
+
+    #[test]
+    fn test_validate_qir_rejects_result_usage_in_ir_defined_helper_with_zero_slots() {
+        let ll_text = r#"
+%Qubit = type opaque
+%Result = type opaque
+
+declare i1 @__quantum__rt__read_result(%Result*)
+
+define internal void @helper() {
+entry:
+  %0 = call i1 @__quantum__rt__read_result(%Result* null)
+  ret void
+}
+
+define i64 @Entry_Point_Name() #0 {
+entry:
+  call void @helper()
+  ret i64 0
+}
+
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_schema"="schema_id" "required_num_qubits"="1" "required_num_results"="0" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+"#;
+
+        let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = validate_qir(&bc_bytes, None).expect_err(
+            "result usage in IR-defined helpers should still respect required_num_results",
+        );
+        assert!(err.contains("Result index 0 exceeds required_num_results (0)"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2655,6 +2655,7 @@ declare void @__quantum__rt__int_record_output(i64, i8*)
         assert!(err.contains("Result index 0 exceeds required_num_results (0)"));
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn test_qir_to_qis_mz_leaked_lowers_via_uint_future_runtime() {
         let bc_bytes = load_fixture_bitcode("tests/data/mz_leaked.ll");
@@ -2672,6 +2673,19 @@ declare void @__quantum__rt__int_record_output(i64, i8*)
         assert!(text.contains("___read_future_uint"));
         assert!(text.contains("___dec_future_refcount"));
         assert!(!text.contains("___read_future_bool"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_qir_to_qis_mz_leaked_windows_smoke() {
+        let bc_bytes = load_fixture_bitcode("tests/data/mz_leaked.ll");
+        let output_bc = qir_to_qis(&bc_bytes, 0, "native", None)
+            .expect("mz_leaked fixture should compile successfully on Windows");
+
+        let ctx = Context::create();
+        let module = parse_bitcode_module(&ctx, &output_bc, "mz_leaked_qis")
+            .expect("Compiled QIS bitcode should parse on Windows");
+        assert!(module.get_function("qmain").is_some());
     }
 
     #[cfg(feature = "wasm")]

--- a/tests/data/mz_leaked.ll
+++ b/tests/data/mz_leaked.ll
@@ -1,0 +1,21 @@
+%Qubit = type opaque
+
+@0 = private constant [7 x i8] c"leaked\00"
+
+define i64 @Entry_Point_Name() #0 {
+entry:
+  %0 = call i64 @__quantum__qis__mz_leaked__body(%Qubit* null)
+  call void @__quantum__rt__int_record_output(i64 %0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @0, i64 0, i64 0))
+  ret i64 0
+}
+
+declare i64 @__quantum__qis__mz_leaked__body(%Qubit*)
+declare void @__quantum__rt__int_record_output(i64, i8*)
+
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_schema"="schema_id" "required_num_qubits"="1" "required_num_results"="0" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}

--- a/tests/snaps/mz_leaked.ll.snap
+++ b/tests/snaps/mz_leaked.ll.snap
@@ -1,0 +1,85 @@
+---
+source: src/convert.rs
+assertion_line: 2279
+expression: qis_text.to_string()
+---
+; ModuleID = 'qis_module'
+source_filename = "qir"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-unknown-linux-gnu"
+
+@qis_qs = private unnamed_addr global [1 x i64] zeroinitializer
+@e_qalloc_fail = private constant [47 x i8] c".EXIT:INT:No more qubits available to allocate."
+@res_leaked.1 = private constant [16 x i8] c"\0FUSER:INT:leaked"
+@gen_name = local_unnamed_addr global [7 x i8] c"qir-qis", section ",generator"
+@gen_version = local_unnamed_addr global [5 x i8] c"0.0.0", section ",generator"
+
+define noundef i64 @___user_qir_Entry_Point_Name() local_unnamed_addr {
+entry:
+  %qalloc.i = tail call i64 @___qalloc()
+  %is_fail.i = icmp eq i64 %qalloc.i, -1
+  br i1 %is_fail.i, label %qalloc_fail.i, label %qir_qis.init_qubit.exit
+
+qalloc_fail.i:                                    ; preds = %entry
+  tail call void @panic(i32 1001, ptr nonnull @e_qalloc_fail)
+  unreachable
+
+qir_qis.init_qubit.exit:                          ; preds = %entry
+  tail call void @___reset(i64 %qalloc.i)
+  store i64 %qalloc.i, ptr @qis_qs, align 8
+  %meas_leaked = tail call i64 @___lazy_measure_leaked(i64 %qalloc.i)
+  %meas_leaked_value = tail call i64 @___read_future_uint(i64 %meas_leaked)
+  tail call void @___dec_future_refcount(i64 %meas_leaked)
+  tail call void @print_int(ptr nonnull @res_leaked.1, i64 15, i64 %meas_leaked_value)
+  %qbit1 = load i64, ptr @qis_qs, align 8
+  tail call void @___qfree(i64 %qbit1)
+  ret i64 0
+}
+
+declare i64 @___qalloc() local_unnamed_addr
+
+declare void @panic(i32, ptr) local_unnamed_addr
+
+declare void @___reset(i64) local_unnamed_addr
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(read, argmem: none, inaccessiblemem: none)
+define i64 @qir_qis.load_qubit(ptr %0) local_unnamed_addr #0 {
+entry:
+  %idx = ptrtoint ptr %0 to i64
+  %qbit_ptr = getelementptr [1 x i64], ptr @qis_qs, i64 0, i64 %idx
+  %qbit = load i64, ptr %qbit_ptr, align 8
+  ret i64 %qbit
+}
+
+declare i64 @___lazy_measure_leaked(i64) local_unnamed_addr
+
+declare i64 @___read_future_uint(i64) local_unnamed_addr
+
+declare void @___dec_future_refcount(i64) local_unnamed_addr
+
+declare void @print_int(ptr, i64, i64) local_unnamed_addr
+
+declare void @___qfree(i64) local_unnamed_addr
+
+define i64 @qmain(i64 %0) local_unnamed_addr {
+entry:
+  tail call void @setup(i64 %0)
+  %1 = tail call i64 @___user_qir_Entry_Point_Name()
+  %retval = tail call i64 @teardown()
+  ret i64 %retval
+}
+
+declare void @setup(i64) local_unnamed_addr
+
+declare i64 @teardown() local_unnamed_addr
+
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(read, argmem: none, inaccessiblemem: none) }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!name = !{!4}
+
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+!4 = !{!"mainlib"}


### PR DESCRIPTION
## Summary
- add public QIR support for `__quantum__qis__mz_leaked__body(%Qubit*) -> i64`
- lower leaked measurement through `___lazy_measure_leaked`, `___read_future_uint`, and `___dec_future_refcount`
- allow `required_num_results="0"` for leaked-measure programs while keeping legacy `%Result`-backed flows unchanged
- add `tests/data/mz_leaked.ll` and snapshot coverage for the lowered output
- update `qtm-qir-reference.md` to document `mz_leaked` in the QIS reference

## Why
Issue #68 asks for parity with the existing HUGR leaked-measure path without exposing runtime futures in the public QIR contract.

Before this change, `qir-qis` only supported `%Result`-backed measurement via `mz` and `read_result`, so leaked measurement expressed as a direct integer-valued QIR operation could not validate or lower.

## Impact
- QIR can now express leaked measurement as a direct classical `i64`-returning instruction
- leaked measurement can be recorded through `__quantum__rt__int_record_output`
- `%Result`-backed measurement still requires valid `required_num_results` slots
- the test suite covers the new fixture across normal translation checks, snapshot coverage, and Windows smoke coverage

## Validation
- `cargo test test_snapshot_conversion -- --nocapture`
- `cargo test mz_leaked -- --nocapture`
- `cargo test --all-features`

Closes #68
