### PR TITLE
chore: exclude LLVM fixtures from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Exclude LLVM test fixtures from language stats without hiding their diffs.
+tests/data/** linguist-vendored
+
+# Snapshot outputs are generated artifacts and can be hidden in diffs.
+tests/snaps/** linguist-generated


### PR DESCRIPTION
## Summary
- add a root `.gitattributes` file for GitHub Linguist overrides
- mark `tests/data/**` as `linguist-vendored` so LLVM fixtures stay out of language stats without hiding their diffs
- mark `tests/snaps/**` as `linguist-generated` so snapshot diffs get the same hidden-by-default treatment as lock files

## Why
GitHub was counting LLVM fixtures and snapshot artifacts toward the repository language breakdown. This keeps those generated or fixture-heavy paths from skewing stats while preserving the intended PR review behavior for each path class.

## Validation
- no runtime tests run; metadata-only change
- confirmed the behavior against GitHub's `customizing-how-changed-files-appear-on-github` docs and Linguist override docs
