### PR TITLE
ci: skip branch commit guard in lint workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,6 +148,8 @@ jobs:
           cache-workspace-crates: true
           cache-targets: true
       - name: Run pre-commit lint
+        env:
+          SKIP: no-commit-to-branch
         run: uvx prek run --all-files
       - name: Verify Python stubs are up to date
         if: github.event_name == 'pull_request' && steps.stub_changes.outputs.lib_rs == 'true'


### PR DESCRIPTION
## Summary

- Skip the `no-commit-to-branch` hook when CI runs the full `prek` lint suite.
- Keep the hook active for local commits while avoiding failures on regular `main` push runs.

Fixes the `main` push [CI failure from run 25113921477](https://github.com/Quantinuum/qir-qis/actions/runs/25113921477/job/73595405342).

## Validation

- `SKIP=no-commit-to-branch uvx prek run --all-files`
- `make test`