### PR TITLE
fix: eliminate code scanning false positives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2062,17 +2062,13 @@ mod aux {
         function
     }
 
-    #[allow(
-        clippy::or_fun_call,
-        reason = "direct ok_or avoids a CodeQL false positive on the opname capture"
-    )]
     fn extract_const_len(value: BasicValueEnum<'_>, opname: &str) -> Result<u64, String> {
-        value
-            .into_int_value()
-            .get_zero_extended_constant()
-            .ok_or(format!(
+        let Some(len) = value.into_int_value().get_zero_extended_constant() else {
+            return Err(format!(
                 "{opname} currently requires a constant array length"
-            ))
+            ));
+        };
+        Ok(len)
     }
 
     fn lower_void_helper_call<'ctx>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,15 +428,15 @@ mod aux {
             return;
         };
 
-        if major_values.iter().any(|major| {
-            minor_values.iter().any(|minor| {
-                matches!(
-                    (major.as_str(), minor.as_str()),
+        for major_value in major_values {
+            for minor_value in minor_values {
+                if matches!(
+                    (major_value.as_str(), minor_value.as_str()),
                     ("i32 1", "i32 0") | ("i32 2", "i32 0" | "i32 1")
-                )
-            })
-        }) {
-            return;
+                ) {
+                    return;
+                }
+            }
         }
 
         if !major_values
@@ -1535,9 +1535,10 @@ mod aux {
         build_error: &str,
         value_error: &str,
     ) -> Result<BasicValueEnum<'ctx>, String> {
-        let call = builder
-            .build_call(callee, args, name)
-            .map_err(|e| format!("{build_error}: {e}"))?;
+        let call = match builder.build_call(callee, args, name) {
+            Ok(call) => call,
+            Err(err) => return Err(format!("{build_error}: {err}")),
+        };
         match call.try_as_basic_value() {
             inkwell::values::ValueKind::Basic(bv) => Ok(bv),
             inkwell::values::ValueKind::Instruction(_) => Err(value_error.to_string()),
@@ -2061,11 +2062,17 @@ mod aux {
         function
     }
 
+    #[allow(
+        clippy::or_fun_call,
+        reason = "direct ok_or avoids a CodeQL false positive on the opname capture"
+    )]
     fn extract_const_len(value: BasicValueEnum<'_>, opname: &str) -> Result<u64, String> {
         value
             .into_int_value()
             .get_zero_extended_constant()
-            .ok_or_else(|| format!("{opname} currently requires a constant array length"))
+            .ok_or(format!(
+                "{opname} currently requires a constant array length"
+            ))
     }
 
     fn lower_void_helper_call<'ctx>(
@@ -2079,9 +2086,9 @@ mod aux {
         builder.position_before(&instr);
         let metadata_args: Vec<BasicMetadataValueEnum<'ctx>> =
             call_args.iter().copied().map(Into::into).collect();
-        let _ = builder
-            .build_call(helper, &metadata_args, "")
-            .map_err(|e| format!("{error_context}: {e}"))?;
+        if let Err(err) = builder.build_call(helper, &metadata_args, "") {
+            return Err(format!("{error_context}: {err}"));
+        }
         instr.erase_from_basic_block();
         Ok(())
     }
@@ -3101,9 +3108,9 @@ mod aux {
     ) -> Result<(), String> {
         let builder = ctx.create_builder();
         builder.position_before(&instr);
-        let _ = builder
-            .build_call(callee, call_args, "")
-            .map_err(|e| format!("{build_error}: {e}"))?;
+        if let Err(err) = builder.build_call(callee, call_args, "") {
+            return Err(format!("{build_error}: {err}"));
+        }
         instr.erase_from_basic_block();
         Ok(())
     }
@@ -3893,6 +3900,17 @@ attributes #0 = {{ "entry_point" "qir_profiles"="base_profile" "output_labeling_
     }
 
     fn minimal_qir_missing_attr(missing_attr: &str) -> String {
+        #[allow(
+            clippy::option_if_let_else,
+            reason = "explicit match avoids a CodeQL false positive on the attribute name capture"
+        )]
+        fn render_attr(name: &str, value: Option<&str>) -> String {
+            match value {
+                Some(value) => format!(r#""{name}"="{value}""#),
+                None => format!(r#""{name}""#),
+            }
+        }
+
         let attrs = [
             ("entry_point", None),
             ("qir_profiles", Some("base_profile")),
@@ -3903,12 +3921,7 @@ attributes #0 = {{ "entry_point" "qir_profiles"="base_profile" "output_labeling_
         let rendered_attrs = attrs
             .into_iter()
             .filter(|(name, _)| *name != missing_attr)
-            .map(|(name, value)| {
-                value.map_or_else(
-                    || format!(r#""{name}""#),
-                    |value| format!(r#""{name}"="{value}""#),
-                )
-            })
+            .map(|(name, value)| render_attr(name, value))
             .collect::<Vec<_>>()
             .join(" ");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3896,17 +3896,6 @@ attributes #0 = {{ "entry_point" "qir_profiles"="base_profile" "output_labeling_
     }
 
     fn minimal_qir_missing_attr(missing_attr: &str) -> String {
-        #[allow(
-            clippy::option_if_let_else,
-            reason = "explicit match avoids a CodeQL false positive on the attribute name capture"
-        )]
-        fn render_attr(name: &str, value: Option<&str>) -> String {
-            match value {
-                Some(value) => format!(r#""{name}"="{value}""#),
-                None => format!(r#""{name}""#),
-            }
-        }
-
         let attrs = [
             ("entry_point", None),
             ("qir_profiles", Some("base_profile")),
@@ -3917,7 +3906,12 @@ attributes #0 = {{ "entry_point" "qir_profiles"="base_profile" "output_labeling_
         let rendered_attrs = attrs
             .into_iter()
             .filter(|(name, _)| *name != missing_attr)
-            .map(|(name, value)| render_attr(name, value))
+            .map(|(name, value)| {
+                value.map_or_else(
+                    || format!(r#""{name}""#),
+                    |value| format!(r#""{name}"="{value}""#),
+                )
+            })
             .collect::<Vec<_>>()
             .join(" ");
 

--- a/src/llvm_verify.rs
+++ b/src/llvm_verify.rs
@@ -2,8 +2,8 @@ use inkwell::module::Module;
 #[cfg(windows)]
 use llvm_sys::analysis::{LLVMVerifierFailureAction, LLVMVerifyModule};
 
+#[cfg(windows)]
 pub fn verify_module(module: &Module, error_prefix: &str) -> Result<(), String> {
-    #[cfg(windows)]
     let verify_rc = unsafe {
         LLVMVerifyModule(
             module.as_mut_ptr(),
@@ -12,25 +12,22 @@ pub fn verify_module(module: &Module, error_prefix: &str) -> Result<(), String> 
         )
     };
 
-    #[cfg(windows)]
-    {
-        if verify_rc == 0 {
-            return Ok(());
-        }
-        // Re-checked locally on Windows Arm64 on March 23, 2026: asking LLVM
-        // to populate the verifier message pointer led to process instability,
-        // so keep the Windows path on the null-pointer fallback for now.
-        return Err(format!(
-            "{error_prefix}: LLVM verifier failed (message pointer unavailable on this platform; rerun on Linux/macOS for detailed verifier diagnostics)"
-        ));
+    if verify_rc == 0 {
+        return Ok(());
     }
+    // Re-checked locally on Windows Arm64 on March 23, 2026: asking LLVM
+    // to populate the verifier message pointer led to process instability,
+    // so keep the Windows path on the null-pointer fallback for now.
+    Err(format!(
+        "{error_prefix}: LLVM verifier failed (message pointer unavailable on this platform; rerun on Linux/macOS for detailed verifier diagnostics)"
+    ))
+}
 
-    #[cfg(not(windows))]
-    {
-        module
-            .verify()
-            .map_err(|err| format!("{error_prefix}: {err}"))
-    }
+#[cfg(not(windows))]
+pub fn verify_module(module: &Module, error_prefix: &str) -> Result<(), String> {
+    module
+        .verify()
+        .map_err(|err| format!("{error_prefix}: {err}"))
 }
 
 #[cfg(test)]

--- a/src/llvm_verify.rs
+++ b/src/llvm_verify.rs
@@ -25,9 +25,10 @@ pub fn verify_module(module: &Module, error_prefix: &str) -> Result<(), String> 
 
 #[cfg(not(windows))]
 pub fn verify_module(module: &Module, error_prefix: &str) -> Result<(), String> {
-    module
-        .verify()
-        .map_err(|err| format!("{error_prefix}: {err}"))
+    match module.verify() {
+        Ok(()) => Ok(()),
+        Err(err) => Err(format!("{error_prefix}: {err}")),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- refactor the helper paths in `src/lib.rs` that CodeQL was misreading so the open `rust/unused-variable` alerts on `build_error`, `error_context`, `opname`, and `major` are eliminated without changing behavior
- rewrite `verify_module` in `src/llvm_verify.rs` so both platform-specific paths reference `error_prefix` directly and the corresponding alert is removed

## Validation
- `make lint`
- `make test`

## Notes
- this PR targets the current `rust/unused-variable` code-scanning notes rather than a user-visible product bug
- alert https://github.com/Quantinuum/qir-qis/security/code-scanning/11 on `minimal_qir_missing_attr` remains a CodeQL false positive: `name` is used in both formatting branches, and the preferred fix is dismissal in the Security UI rather than a code-only workaround
- I did not add regression tests because the change is analysis-structure-only and both existing validation targets stayed green