### PR TITLE
ci: stop passing PAT to release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,8 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
+          token: ${{ secrets.HUGRBOT_PAT }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         with:
-          token: ${{ secrets.HUGRBOT_PAT }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json


### PR DESCRIPTION
### Motivation
- Prevent exposure of a long-lived personal access token to a third-party action referenced by a mutable tag, reducing supply-chain risk while preserving Release Please's operation under the workflow-scoped `GITHUB_TOKEN` constrained by the workflow `permissions` block.

### Description
- Remove the explicit `token: ${{ secrets.HUGRBOT_PAT }}` input from `.github/workflows/release-please.yml`, leaving the action to use the workflow `GITHUB_TOKEN` and keeping existing `permissions` unchanged.

### Testing
- Attempted `make lint` (failed due to network access to PyPI), `make test` (failed because `cargo-nextest` is not installed), and `cargo test --all-features` (failed due to missing LLVM toolchain / `LLVM_SYS_211_PREFIX`); none completed in this environment, and the change is a one-line workflow edit with no production code exercised by unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a12fba5e42c832299307dee3c84d1c1)