### PR TITLE
fix: reject raw ___barrier QTM declarations during validation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,18 +194,6 @@ mod aux {
     }
 
     #[cfg(feature = "wasm")]
-    static ALLOWED_QTM_FNS: [&str; 8] = [
-        "___get_current_shot",
-        "___random_seed",
-        "___random_int",
-        "___random_float",
-        "___random_int_bounded",
-        "___random_advance",
-        "___get_wasm_context",
-        "___barrier",
-    ];
-
-    #[cfg(not(feature = "wasm"))]
     static ALLOWED_QTM_FNS: [&str; 7] = [
         "___get_current_shot",
         "___random_seed",
@@ -213,7 +201,17 @@ mod aux {
         "___random_float",
         "___random_int_bounded",
         "___random_advance",
-        "___barrier",
+        "___get_wasm_context",
+    ];
+
+    #[cfg(not(feature = "wasm"))]
+    static ALLOWED_QTM_FNS: [&str; 6] = [
+        "___get_current_shot",
+        "___random_seed",
+        "___random_int",
+        "___random_float",
+        "___random_int_bounded",
+        "___random_advance",
     ];
 
     #[cfg(not(windows))]
@@ -4701,6 +4699,32 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
         let err = validate_qir(&bc_bytes, None)
             .expect_err("unsupported QTM declarations should fail validation");
         assert!(err.contains("Unsupported Qtm QIS function: ___unknown_qtm"));
+    }
+
+    #[test]
+    fn test_validate_qir_rejects_raw_barrier_runtime_function() {
+        let ll_text = r#"
+declare void @___barrier(ptr, i64)
+
+define i64 @Entry_Point_Name() #0 {
+entry:
+  call void @___barrier(ptr null, i64 1)
+  ret i64 0
+}
+
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_schema"="schema_id" "required_num_qubits"="1" "required_num_results"="1" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+"#;
+
+        let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = validate_qir(&bc_bytes, None)
+            .expect_err("raw ___barrier declarations should fail validation");
+        assert!(err.contains("Unsupported Qtm QIS function: ___barrier"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1143,6 +1143,9 @@ mod aux {
                 // External context calls are left as-is for downstream processing
                 log::debug!("___get_wasm_context found, leaving as-is for downstream processing");
             }
+            "___barrier" => {
+                return Err("Unsupported Qtm QIS function: ___barrier".to_string());
+            }
             _ => {
                 // Ignore already converted Qtm QIS functions
                 log::trace!("Ignoring Qtm QIS function: {}", args.fn_name);
@@ -4724,6 +4727,32 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
         let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
         let err = validate_qir(&bc_bytes, None)
             .expect_err("raw ___barrier declarations should fail validation");
+        assert!(err.contains("Unsupported Qtm QIS function: ___barrier"));
+    }
+
+    #[test]
+    fn test_qir_to_qis_rejects_raw_barrier_runtime_function() {
+        let ll_text = r#"
+declare void @___barrier(ptr, i64)
+
+define i64 @Entry_Point_Name() #0 {
+entry:
+  call void @___barrier(ptr null, i64 1)
+  ret i64 0
+}
+
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_schema"="schema_id" "required_num_qubits"="1" "required_num_results"="1" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+"#;
+
+        let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = qir_to_qis(&bc_bytes, 0, "native", None)
+            .expect_err("raw ___barrier declarations should fail translation");
         assert!(err.contains("Unsupported Qtm QIS function: ___barrier"));
     }
 


### PR DESCRIPTION
### Motivation
- Prevent attacker-supplied QIR from declaring or calling the internal runtime `___barrier(ptr, i64)` directly, which bypasses fixed-arity checks and safe qubit-handle array construction performed by barrier lowering.
- Keep the safe lowering path from `__quantum__qis__barrierN__body` to an internal `___barrier` call intact while tightening both validation and direct translation behavior.

### Description
- Remove `___barrier` from both `ALLOWED_QTM_FNS` arrays so raw `___barrier` declarations are rejected during `validate_qir`.
- Reject raw `___barrier` during `qir_to_qis` as well by returning `Unsupported Qtm QIS function: ___barrier` from the `handle_qtm_call` path.
- Add focused regressions covering both `validate_qir` and `qir_to_qis` for raw `___barrier(ptr, i64)` declarations.
- Preserve the existing lowering path that emits `___barrier` only when produced from verified `__quantum__qis__barrierN__body` intrinsics.

### Testing
- `cargo test --all-features raw_barrier_runtime_function`
- GitHub Actions CI is green on the current PR head.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a12fe5e963c8322a5846480bcaab0f0)