### PR TITLE
fix: avoid panic on malformed module flag names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,9 @@ mod aux {
     pub fn validate_module_flags(module: &Module, errors: &mut Vec<String>) {
         let module_flags = collect_module_flags(module);
         if module_flags.has_malformed_name() {
-            errors.push("Malformed llvm.module.flags entry: expected metadata string name".to_string());
+            errors.push(
+                "Malformed llvm.module.flags entry: expected metadata string name".to_string(),
+            );
         }
         validate_qir_version_flags(&module_flags, errors);
         validate_exact_module_flag(
@@ -485,7 +487,7 @@ mod aux {
             self.values.get(flag_name).map(Vec::as_slice)
         }
 
-        fn has_malformed_name(&self) -> bool {
+        const fn has_malformed_name(&self) -> bool {
             self.has_malformed_name
         }
 
@@ -4448,8 +4450,9 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
 "#;
 
         let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
-        let err = validate_qir(&bc_bytes, None)
-            .expect_err("Malformed module flag names should fail even with complete required flags");
+        let err = validate_qir(&bc_bytes, None).expect_err(
+            "Malformed module flag names should fail even with complete required flags",
+        );
         assert!(err.contains("Malformed llvm.module.flags entry: expected metadata string name"));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,6 +405,9 @@ mod aux {
 
     pub fn validate_module_flags(module: &Module, errors: &mut Vec<String>) {
         let module_flags = collect_module_flags(module);
+        if module_flags.has_malformed_name() {
+            errors.push("Malformed llvm.module.flags entry: expected metadata string name".to_string());
+        }
         validate_qir_version_flags(&module_flags, errors);
         validate_exact_module_flag(
             &module_flags,
@@ -473,12 +476,17 @@ mod aux {
 
     pub struct ModuleFlags {
         values: BTreeMap<String, Vec<String>>,
+        has_malformed_name: bool,
         malformed: BTreeSet<String>,
     }
 
     impl ModuleFlags {
         pub fn get(&self, flag_name: &str) -> Option<&[String]> {
             self.values.get(flag_name).map(Vec::as_slice)
+        }
+
+        fn has_malformed_name(&self) -> bool {
+            self.has_malformed_name
         }
 
         fn is_malformed(&self, flag_name: &str) -> bool {
@@ -488,6 +496,7 @@ mod aux {
 
     pub fn collect_module_flags(module: &Module) -> ModuleFlags {
         let mut values = BTreeMap::<String, Vec<String>>::new();
+        let mut has_malformed_name = false;
         let mut malformed = BTreeSet::new();
 
         for entry in module.get_global_metadata("llvm.module.flags") {
@@ -495,6 +504,9 @@ mod aux {
                 continue;
             };
             let flag_name = extract_module_flag_name(&node_values);
+            if flag_name.is_none() {
+                has_malformed_name = true;
+            }
 
             if node_values.len() != 3 {
                 if let Some(flag_name) = flag_name {
@@ -519,11 +531,15 @@ mod aux {
             values.entry(flag_name).or_default().push(flag_value);
         }
 
-        ModuleFlags { values, malformed }
+        ModuleFlags {
+            values,
+            has_malformed_name,
+            malformed,
+        }
     }
 
     fn extract_module_flag_name(values: &[BasicMetadataValueEnum]) -> Option<String> {
-        match values.get(1)? {
+        match values.get(1).copied()? {
             BasicMetadataValueEnum::MetadataValue(value) => value
                 .get_string_value()
                 .and_then(decode_llvm_bytes)
@@ -4411,6 +4427,30 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
         let err = validate_qir(&bc_bytes, None)
             .expect_err("Non-metadata module flag name operand should fail validation");
         assert!(err.contains("Missing required module flag: qir_major_version"));
+    }
+
+    #[test]
+    fn test_validate_module_flags_rejects_malformed_name_even_when_required_flags_exist() {
+        let ll_text = r#"
+define i64 @Entry_Point_Name() #0 {
+entry:
+  ret i64 0
+}
+
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_schema"="schema_id" "required_num_qubits"="1" "required_num_results"="1" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!0 = !{i32 1, i32 123, i32 2}
+!1 = !{i32 1, !"qir_major_version", i32 1}
+!2 = !{i32 7, !"qir_minor_version", i32 0}
+!3 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!4 = !{i32 1, !"dynamic_result_management", i1 false}
+"#;
+
+        let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = validate_qir(&bc_bytes, None)
+            .expect_err("Malformed module flag names should fail even with complete required flags");
+        assert!(err.contains("Malformed llvm.module.flags entry: expected metadata string name"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,12 +523,13 @@ mod aux {
     }
 
     fn extract_module_flag_name(values: &[BasicMetadataValueEnum]) -> Option<String> {
-        values
-            .get(1)?
-            .into_metadata_value()
-            .get_string_value()
-            .and_then(decode_llvm_bytes)
-            .map(str::to_owned)
+        match values.get(1)? {
+            BasicMetadataValueEnum::MetadataValue(value) => value
+                .get_string_value()
+                .and_then(decode_llvm_bytes)
+                .map(str::to_owned),
+            _ => None,
+        }
     }
 
     fn format_module_flag_value(value: BasicMetadataValueEnum) -> Option<String> {
@@ -4381,6 +4382,29 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
         let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
         let err = validate_qir(&bc_bytes, None).expect_err("Malformed module flag should fail");
         assert!(err.contains("Missing or unsupported module flag: qir_major_version"));
+    }
+
+    #[test]
+    fn test_validate_module_flags_with_non_metadata_name_operand_does_not_panic() {
+        let ll_text = r#"
+define i64 @Entry_Point_Name() #0 {
+entry:
+  ret i64 0
+}
+
+attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_schema"="schema_id" "required_num_qubits"="1" "required_num_results"="1" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!0 = !{i32 1, i32 123, i32 2}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+"#;
+
+        let bc_bytes = qir_ll_to_bc(ll_text).expect("Failed to convert inline QIR to bitcode");
+        let err = validate_qir(&bc_bytes, None)
+            .expect_err("Non-metadata module flag name operand should fail validation");
+        assert!(err.contains("Missing required module flag: qir_major_version"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,7 +528,13 @@ mod aux {
                 .get_string_value()
                 .and_then(decode_llvm_bytes)
                 .map(str::to_owned),
-            _ => None,
+            BasicMetadataValueEnum::ArrayValue(_)
+            | BasicMetadataValueEnum::IntValue(_)
+            | BasicMetadataValueEnum::FloatValue(_)
+            | BasicMetadataValueEnum::PointerValue(_)
+            | BasicMetadataValueEnum::StructValue(_)
+            | BasicMetadataValueEnum::VectorValue(_)
+            | BasicMetadataValueEnum::ScalableVectorValue(_) => None,
         }
     }
 


### PR DESCRIPTION
### Motivation
- The parser previously assumed the second operand of `llvm.module.flags` nodes was metadata and called unchecked conversions, which can panic on crafted bitcode and cause a denial-of-service.
- Validation should treat malformed metadata as a validation error (`Err`) rather than allowing a host-process panic, preserving deterministic failure behavior for untrusted inputs.

### Description
- Replace the unchecked `into_metadata_value()` usage with a safe pattern match for `BasicMetadataValueEnum::MetadataValue` in `extract_module_flag_name` in `src/lib.rs` so non-metadata operands are ignored and reported as malformed.
- Preserve the existing behavior of collecting valid module-flag values and recording malformed entries in the `ModuleFlags` `malformed` set so validation can report them.
- Add a focused regression test `test_validate_module_flags_with_non_metadata_name_operand_does_not_panic` that feeds `llvm.module.flags` where the name operand is an `i32` and asserts `validate_qir` returns an `Err` instead of panicking.

### Testing
- Ran `cargo test --all-features`, which failed to complete in this environment due to a missing system LLVM toolchain required by `llvm-sys` (build error), so full test execution could not be verified here.
- Ran `make test`, which failed in this environment because `cargo-nextest` is not installed, so CI-style test runner did not run locally.
- Ran `make lint`, which failed due to an environment network limitation fetching a Python lint dependency, so lint checks could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a12fc05a038832289338dfcf2a4a767)