### PR TITLE
fix: avoid panic on malformed dynamic array RT calls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -717,6 +717,12 @@ mod aux {
                         ));
                         continue;
                     }
+                    let BasicValueEnum::IntValue(_) = call_args[0] else {
+                        errors.push(format!(
+                            "{fn_name} requires a constant array length and backing array pointer"
+                        ));
+                        continue;
+                    };
                     let requested_len = match extract_const_len(call_args[0], fn_name) {
                         Ok(len) => len,
                         Err(err) => {
@@ -6001,6 +6007,35 @@ attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "output_labeli
         ));
         assert!(err.contains(
             "__quantum__rt__qubit_array_allocate requires a constant array length and backing array pointer"
+        ));
+    }
+
+    #[test]
+    fn test_validate_dynamic_result_array_allocate_pointer_length_fails_without_panic() {
+        let ll_text = r#"
+define i64 @Entry_Point_Name() #0 {
+entry:
+  %len = alloca ptr, align 8
+  %results = alloca [2 x ptr], align 8
+  call void @__quantum__rt__result_array_allocate(ptr %len, ptr %results, ptr null)
+  ret i64 0
+}
+
+declare void @__quantum__rt__result_array_allocate(ptr, ptr, ptr)
+
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "output_labeling_schema"="schema_id" "required_num_qubits"="1" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!0 = !{i32 1, !"qir_major_version", i32 2}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 true}
+!3 = !{i32 1, !"dynamic_result_management", i1 true}
+!4 = !{i32 1, !"arrays", i1 true}
+"#;
+        let bc_bytes = qir_ll_to_bc(ll_text).unwrap();
+        let err = validate_qir(&bc_bytes, None).expect_err("fixture should fail validation");
+        assert!(err.contains(
+            "__quantum__rt__result_array_allocate requires a constant array length and backing array pointer"
         ));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,19 +724,13 @@ mod aux {
                             continue;
                         }
                     };
-                    let backing_ptr = match call_args[1] {
-                        BasicValueEnum::PointerValue(ptr) => ptr,
-                        _ => {
-                            errors.push(format!(
-                                "{fn_name} requires a fixed-size backing array allocated as [N x ptr]"
-                            ));
-                            continue;
-                        }
+                    let BasicValueEnum::PointerValue(backing_ptr) = call_args[1] else {
+                        errors.push(format!(
+                            "{fn_name} requires a fixed-size backing array allocated as [N x ptr]"
+                        ));
+                        continue;
                     };
-                    let backing_len = match get_fixed_pointer_array_len(
-                        backing_ptr,
-                        fn_name,
-                    ) {
+                    let backing_len = match get_fixed_pointer_array_len(backing_ptr, fn_name) {
                         Ok(len) => len,
                         Err(err) => {
                             errors.push(err);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -711,6 +711,12 @@ mod aux {
                             continue;
                         }
                     };
+                    if call_args.len() < 2 {
+                        errors.push(format!(
+                            "{fn_name} requires a constant array length and backing array pointer"
+                        ));
+                        continue;
+                    }
                     let requested_len = match extract_const_len(call_args[0], fn_name) {
                         Ok(len) => len,
                         Err(err) => {
@@ -718,8 +724,17 @@ mod aux {
                             continue;
                         }
                     };
+                    let backing_ptr = match call_args[1] {
+                        BasicValueEnum::PointerValue(ptr) => ptr,
+                        _ => {
+                            errors.push(format!(
+                                "{fn_name} requires a fixed-size backing array allocated as [N x ptr]"
+                            ));
+                            continue;
+                        }
+                    };
                     let backing_len = match get_fixed_pointer_array_len(
-                        call_args[1].into_pointer_value(),
+                        backing_ptr,
                         fn_name,
                     ) {
                         Ok(len) => len,
@@ -5963,6 +5978,36 @@ attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "output_labeli
             err.contains("__quantum__rt__qubit_array_allocate requires a fixed-size backing array")
         );
         assert!(err.contains("requested length 2 does not match backing array length 1"));
+    }
+
+    #[test]
+    fn test_validate_dynamic_qubit_array_allocate_malformed_signature_fails_without_panic() {
+        let ll_text = r#"
+define i64 @Entry_Point_Name() #0 {
+entry:
+  call void @__quantum__rt__qubit_array_allocate()
+  ret i64 0
+}
+
+declare void @__quantum__rt__qubit_array_allocate()
+
+attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "output_labeling_schema"="schema_id" "required_num_results"="1" }
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+!0 = !{i32 1, !"qir_major_version", i32 2}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 true}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+!4 = !{i32 1, !"arrays", i1 true}
+"#;
+        let bc_bytes = qir_ll_to_bc(ll_text).unwrap();
+        let err = validate_qir(&bc_bytes, None).expect_err("fixture should fail validation");
+        assert!(err.contains(
+            "Malformed QIR RT function declaration: __quantum__rt__qubit_array_allocate"
+        ));
+        assert!(err.contains(
+            "__quantum__rt__qubit_array_allocate requires a constant array length and backing array pointer"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service panic when validating malformed-but-LLVM-valid dynamic array runtime declarations and calls such as `__quantum__rt__qubit_array_allocate()` with zero parameters.
- The previous flow collected signature errors but continued into deeper operand inspection that used unchecked indexing and `into_*_value()` conversions, which can panic on the wrong `BasicValueEnum` variant.

### Description
- Add an operand-count guard in `validate_dynamic_array_allocation_backing` to require at least two operands before indexing into `call_args`.
- Replace the unchecked `call_args[1].into_pointer_value()` usage with a safe match on `BasicValueEnum::PointerValue` and emit a validation error if the second operand is not a pointer.
- Keep existing behavior of comparing `requested_len` and `backing_len` and checking `RESULT_ARRAY` size constraints.
- Add a regression test `test_validate_dynamic_qubit_array_allocate_malformed_signature_fails_without_panic` that exercises a zero-argument `__quantum__rt__qubit_array_allocate` call and asserts the validator returns explicit errors rather than panicking.

### Testing
- Ran `make lint` which failed in this environment due to an external dependency fetch error for `prek` from PyPI (network/PyPI issue), so lint could not be completed here.
- Ran `make test` which failed because `cargo nextest` is not installed in the environment, so the Makefile test target could not run.
- Ran `cargo test --all-features` which failed during compilation because `llvm-sys` could not find a suitable LLVM 21 installation on the host; the added unit test is present and should pass when built in an environment with the expected LLVM toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a12fb3b97188322826a8364759c0389)