### PR TITLE
fix: reduce workflow token permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: write
   contents: read
   pull-requests: read
 
@@ -37,10 +38,6 @@ env:
 
 jobs:
   test:
-    permissions:
-      actions: write
-      contents: read
-      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
@@ -99,10 +96,6 @@ jobs:
         run: uv run -- python tests/test_main.py
 
   lint:
-    permissions:
-      actions: write
-      contents: read
-      pull-requests: read
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,10 @@ env:
 
 jobs:
   test:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +99,10 @@ jobs:
         run: uv run -- python tests/test_main.py
 
   lint:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: write
+  actions: read
   contents: read
   pull-requests: read
 
@@ -74,6 +74,7 @@ jobs:
           cache-on-failure: true
           cache-workspace-crates: true
           cache-targets: true
+          save-if: "false"
       - name: Test (Windows suite)
         if: runner.os == 'Windows'
         run: cargo nextest run --lib --all-features --test-threads=1 -E "not test(test_get_entry_attributes)"
@@ -132,8 +133,8 @@ jobs:
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             cargo binstall --no-confirm --force cargo-msrv
           fi
-      - name: Cache sccache
-        uses: actions/cache@v5
+      - name: Restore sccache
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/sccache
           key: sccache-${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('**/Cargo.lock') }}
@@ -145,6 +146,7 @@ jobs:
           cache-on-failure: true
           cache-workspace-crates: true
           cache-targets: true
+          save-if: "false"
       - name: Run pre-commit lint
         env:
           SKIP: no-commit-to-branch

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: write
   contents: read
   pull-requests: read
 
@@ -51,6 +50,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install hugrenv LLVM
         uses: Quantinuum/hugrverse-env/install-hugrenv-action@v1.0.0
         with:
@@ -99,6 +100,8 @@ jobs:
       RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Detect stub-affecting changes
         id: stub_changes
         if: github.event_name == 'pull_request'

--- a/.github/workflows/wheels-release.yml
+++ b/.github/workflows/wheels-release.yml
@@ -18,7 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: write
   contents: read
 
 jobs:

--- a/.github/workflows/wheels-release.yml
+++ b/.github/workflows/wheels-release.yml
@@ -18,6 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: write
   contents: read
 
 jobs:
@@ -71,9 +72,6 @@ jobs:
     name: ${{ matrix.os }} wheels
     runs-on: ${{ matrix.os }}
     needs: [prepare_release_context]
-    permissions:
-      actions: write
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +108,6 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [prepare_release_context, build_wheels]
     permissions:
-      actions: write
       # Use to sign the release artifacts
       id-token: write
       # Used to upload release artifacts

--- a/.github/workflows/wheels-release.yml
+++ b/.github/workflows/wheels-release.yml
@@ -71,6 +71,9 @@ jobs:
     name: ${{ matrix.os }} wheels
     runs-on: ${{ matrix.os }}
     needs: [prepare_release_context]
+    permissions:
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +110,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [prepare_release_context, build_wheels]
     permissions:
+      actions: write
       # Use to sign the release artifacts
       id-token: write
       # Used to upload release artifacts


### PR DESCRIPTION
### Motivation
- Reduce GitHub Actions token scope for CI runs that validate untrusted pull requests.
- Avoid persisting checkout credentials into the working copy for PR-controlled code.

### Description
- Change `.github/workflows/CI.yml` to request `actions: read`, `contents: read`, and `pull-requests: read` instead of a write-capable Actions token.
- Convert CI cache usage to restore-only by setting `Swatinem/rust-cache` `save-if: "false"` and switching the `sccache` step to `actions/cache/restore@v5`, so the workflow no longer needs `actions: write`.
- Keep `persist-credentials: false` on CI checkouts so the workflow token is not written into local git config.
- Remove top-level `actions: write` from `.github/workflows/wheels-release.yml` while preserving the release job's explicit `id-token: write` and `contents: write` permissions required for publishing.

### Testing
- Ran `git diff --check`.
- Inspected the workflow diff to confirm CI now uses restore-only cache steps under `actions: read`.
- Broader repo checks were not rerun for this workflow-only follow-up.
