### PR TITLE
ci: harden fuzz target handling to prevent CI and Makefile command injection

### DIFF
--- a/.github/workflows/robustness.yml
+++ b/.github/workflows/robustness.yml
@@ -102,6 +102,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: fuzz-targets
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/robustness.yml
+++ b/.github/workflows/robustness.yml
@@ -56,6 +56,9 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     needs: fuzz-targets
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -164,6 +167,9 @@ jobs:
   mutants:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/robustness.yml
+++ b/.github/workflows/robustness.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Collect fuzz targets
         id: collect
         run: |
+          # Keep this list in sync with `FUZZ_ALL_TARGETS` in `Makefile`.
           targets='["declared_qis_calls","entry_contracts","get_entry_attributes","mutated_fixture_bitcode","mutated_fixture_contracts","parse_wasm_functions","qir_ll_to_bc","qir_to_qis","result_index_contracts","validate_fixture_with_wasm","validate_qir"]'
           echo "targets=${targets}" >>"$GITHUB_OUTPUT"
 

--- a/.github/workflows/robustness.yml
+++ b/.github/workflows/robustness.yml
@@ -35,7 +35,6 @@ concurrency:
 
 permissions:
   contents: read
-  actions: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -47,17 +46,10 @@ jobs:
     outputs:
       targets: ${{ steps.collect.outputs.targets }}
     steps:
-      - uses: actions/checkout@v6
       - name: Collect fuzz targets
         id: collect
         run: |
-          targets=$(
-            find fuzz/fuzz_targets -maxdepth 1 -name '*.rs' -print |
-              sort |
-              sed 's#.*/##; s#\.rs$##' |
-              jq -R . |
-              jq -sc .
-          )
+          targets='["declared_qis_calls","entry_contracts","get_entry_attributes","mutated_fixture_bitcode","mutated_fixture_contracts","parse_wasm_functions","qir_ll_to_bc","qir_to_qis","result_index_contracts","validate_fixture_with_wasm","validate_qir"]'
           echo "targets=${targets}" >>"$GITHUB_OUTPUT"
 
   fuzz-smoke:
@@ -70,6 +62,8 @@ jobs:
         target: ${{ fromJson(needs.fuzz-targets.outputs.targets) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install hugrenv LLVM
         uses: Quantinuum/hugrverse-env/install-hugrenv-action@v1.0.0
         with:
@@ -96,9 +90,13 @@ jobs:
           cache-workspace-crates: true
           cache-targets: true
       - name: Fuzz check
-        run: cargo +nightly fuzz check --target "${RUST_HOST_TARGET}" ${{ matrix.target }}
+        env:
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: cargo +nightly fuzz check --target "${RUST_HOST_TARGET}" "${FUZZ_TARGET}"
       - name: Fuzz smoke
-        run: cargo +nightly fuzz run --target "${RUST_HOST_TARGET}" ${{ matrix.target }} -- -max_total_time=20
+        env:
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: cargo +nightly fuzz run --target "${RUST_HOST_TARGET}" "${FUZZ_TARGET}" -- -max_total_time=20
 
   fuzz-long:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
@@ -110,6 +108,8 @@ jobs:
         target: ${{ fromJson(needs.fuzz-targets.outputs.targets) }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install hugrenv LLVM
         uses: Quantinuum/hugrverse-env/install-hugrenv-action@v1.0.0
         with:
@@ -136,11 +136,15 @@ jobs:
           cache-workspace-crates: true
           cache-targets: true
       - name: Fuzz check
-        run: cargo +nightly fuzz check --target "${RUST_HOST_TARGET}" ${{ matrix.target }}
+        env:
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: cargo +nightly fuzz check --target "${RUST_HOST_TARGET}" "${FUZZ_TARGET}"
       - name: Fuzz campaign
         id: fuzz_run
         continue-on-error: true
-        run: cargo +nightly fuzz run --target "${RUST_HOST_TARGET}" ${{ matrix.target }} -- -max_total_time=300
+        env:
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: cargo +nightly fuzz run --target "${RUST_HOST_TARGET}" "${FUZZ_TARGET}" -- -max_total_time=300
       - name: Upload fuzz artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -159,6 +163,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install hugrenv LLVM
         uses: Quantinuum/hugrverse-env/install-hugrenv-action@v1.0.0
         with:

--- a/.github/workflows/robustness.yml
+++ b/.github/workflows/robustness.yml
@@ -34,6 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: write
   contents: read
 
 env:
@@ -56,9 +57,6 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     needs: fuzz-targets
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -105,9 +103,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: fuzz-targets
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -167,9 +162,6 @@ jobs:
   mutants:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PYTHON = uv run -- python
 RUST_HOST_TARGET ?= $(shell rustc -vV | sed -n 's/^host: //p')
 FUZZ_TARGET ?= validate_qir
 FUZZ_RUN_ARGS ?= -max_total_time=30
+# Keep this list in sync with `.github/workflows/robustness.yml` `jobs.fuzz-targets`.
 FUZZ_ALL_TARGETS := declared_qis_calls entry_contracts get_entry_attributes mutated_fixture_bitcode mutated_fixture_contracts parse_wasm_functions qir_ll_to_bc qir_to_qis result_index_contracts validate_fixture_with_wasm validate_qir
 
 .PHONY: compile

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON = uv run -- python
 RUST_HOST_TARGET ?= $(shell rustc -vV | sed -n 's/^host: //p')
 FUZZ_TARGET ?= validate_qir
 FUZZ_RUN_ARGS ?= -max_total_time=30
-FUZZ_ALL_TARGETS := $(basename $(notdir $(wildcard fuzz/fuzz_targets/*.rs)))
+FUZZ_ALL_TARGETS := declared_qis_calls entry_contracts get_entry_attributes mutated_fixture_bitcode mutated_fixture_contracts parse_wasm_functions qir_ll_to_bc qir_to_qis result_index_contracts validate_fixture_with_wasm validate_qir
 
 .PHONY: compile
 # Usage:


### PR DESCRIPTION
### Motivation
- Prevent command injection caused by using PR-controlled filenames as fuzz target names in the robustness workflow and by expanding local filenames unquoted in `Makefile` `fuzz-all` loops.
- Keep local and CI fuzz-target coverage aligned now that both sides use the same hard-coded target list.

### Description
- Retain top-level `actions: write` in `.github/workflows/robustness.yml` because the workflow still uses the GitHub Actions cache API and artifact upload, while keeping `contents: read`.
- Replace dynamic discovery of `fuzz/fuzz_targets/*.rs` in the workflow with a fixed, trusted JSON list of fuzz targets and avoid reading PR files when assembling the matrix.
- Disable persisted checkout credentials by adding `persist-credentials: false` to `actions/checkout` in the robustness jobs.
- Pass the matrix entry through an environment variable (`FUZZ_TARGET`) and use the variable quoted in the `run:` lines to ensure shell-safe quoting of target names.
- Replace the `Makefile` dynamic `FUZZ_ALL_TARGETS` expansion with the same fixed list of fuzz targets to prevent local filename-based injection in `make fuzz-all`.
- Add explicit keep-in-sync notes next to the duplicated fuzz-target lists in `Makefile` and `.github/workflows/robustness.yml` to reduce local/CI coverage drift.

### Testing
- Verified a malicious filename such as `x; echo MAKEFILE_INJECTION_CONFIRMED > MAKE_INJECTED; #.rs` no longer appears in a `make -n fuzz-all` plan and does not create `MAKE_INJECTED` (simulation passed).
- Ran `git diff --check`.
- Ran `make -n fuzz-all` to confirm the hardened static target list still expands correctly after the follow-up keep-in-sync note.
- Broader repo checks were not rerun for this comment-only follow-up.
