### PR TITLE
test: cover dynamic array backing operand-count mutants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3881,7 +3881,7 @@ mod test {
         let module = create_module_from_ir_text(&ctx, ll_text, "qir")
             .expect("inline IR should parse for dynamic array backing validation");
         let mut errors = Vec::new();
-        aux::validate_dynamic_array_allocation_backing(&module, &mut errors);
+        crate::aux::validate_dynamic_array_allocation_backing(&module, &mut errors);
         errors
     }
 
@@ -6268,7 +6268,7 @@ attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "output_labeli
 
     #[test]
     fn test_validate_dynamic_qubit_array_release_matching_backing_succeeds() {
-        let ll_text = r#"
+        let ll_text = r"
 define i64 @Entry_Point_Name() {
 entry:
   %qubits = alloca [2 x ptr], align 8
@@ -6277,7 +6277,7 @@ entry:
 }
 
 declare void @__quantum__rt__qubit_array_release(i64, ptr)
-"#;
+";
 
         let errors = validate_dynamic_array_backing_errors(ll_text);
         assert!(
@@ -6288,7 +6288,7 @@ declare void @__quantum__rt__qubit_array_release(i64, ptr)
 
     #[test]
     fn test_validate_dynamic_qubit_array_release_missing_backing_fails_without_panic() {
-        let ll_text = r#"
+        let ll_text = r"
 define i64 @Entry_Point_Name() {
 entry:
   call void @__quantum__rt__qubit_array_release(i64 2)
@@ -6296,7 +6296,7 @@ entry:
 }
 
 declare void @__quantum__rt__qubit_array_release(i64)
-"#;
+";
 
         let errors = validate_dynamic_array_backing_errors(ll_text);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6302,7 +6302,7 @@ declare void @__quantum__rt__qubit_array_release(i64)
         assert_eq!(
             errors,
             vec![
-                "__quantum__rt__qubit_array_release requires a constant array length and backing array pointer"
+                "__quantum__rt__qubit_array_release requires a fixed-size backing array allocated as [N x ptr]"
                     .to_string()
             ]
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3876,6 +3876,15 @@ mod test {
             .map_err(|e| format!("Failed to parse bitcode: {e}"))
     }
 
+    fn validate_dynamic_array_backing_errors(ll_text: &str) -> Vec<String> {
+        let ctx = Context::create();
+        let module = create_module_from_ir_text(&ctx, ll_text, "qir")
+            .expect("inline IR should parse for dynamic array backing validation");
+        let mut errors = Vec::new();
+        aux::validate_dynamic_array_allocation_backing(&module, &mut errors);
+        errors
+    }
+
     fn assert_public_bitcode_round_trips_from_file(bitcode: &[u8], name: &str) {
         let ctx = Context::create();
         let module = parse_bitcode_module(&ctx, bitcode, name)
@@ -6255,6 +6264,48 @@ attributes #0 = { "entry_point" "qir_profiles"="adaptive_profile" "output_labeli
             err.contains("__quantum__rt__result_array_release requires a fixed-size backing array")
         );
         assert!(err.contains("requested length 2 does not match backing array length 1"));
+    }
+
+    #[test]
+    fn test_validate_dynamic_qubit_array_release_matching_backing_succeeds() {
+        let ll_text = r#"
+define i64 @Entry_Point_Name() {
+entry:
+  %qubits = alloca [2 x ptr], align 8
+  call void @__quantum__rt__qubit_array_release(i64 2, ptr %qubits)
+  ret i64 0
+}
+
+declare void @__quantum__rt__qubit_array_release(i64, ptr)
+"#;
+
+        let errors = validate_dynamic_array_backing_errors(ll_text);
+        assert!(
+            errors.is_empty(),
+            "matching two-argument array release should not report backing errors: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_dynamic_qubit_array_release_missing_backing_fails_without_panic() {
+        let ll_text = r#"
+define i64 @Entry_Point_Name() {
+entry:
+  call void @__quantum__rt__qubit_array_release(i64 2)
+  ret i64 0
+}
+
+declare void @__quantum__rt__qubit_array_release(i64)
+"#;
+
+        let errors = validate_dynamic_array_backing_errors(ll_text);
+        assert_eq!(
+            errors,
+            vec![
+                "__quantum__rt__qubit_array_release requires a constant array length and backing array pointer"
+                    .to_string()
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a focused test helper that exercises `aux::validate_dynamic_array_allocation_backing` directly
- cover a valid 2-argument `__quantum__rt__qubit_array_release` call so operand-count mutants do not silently survive
- cover a malformed 1-argument release call to ensure the validator returns a clean error instead of slipping past the guard

## Context
- addresses the `mutants` failure from https://github.com/Quantinuum/qir-qis/actions/runs/27944873964/job/82686980862
- the surviving mutants were both at `src/lib.rs:737` in the `call_args.len() < 2` guard inside `validate_dynamic_array_allocation_backing`

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test dynamic_qubit_array_release --all-features --locked` blocked locally because the configured Cargo source replacement to `artifactory-remote` returned `403 Forbidden` while resolving dependencies
