### PR TITLE
fix(windows): restore optimized llvm21 conversion coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ cargo run -- input.ll
 This generates `input.qis.bc` containing the compiled QIS bitcode.
 
 On Windows, the default mode remains conservative: `-O 0 -t native`. Optimized
-conversion is supported with `-t x86-64`; other optimized target combinations
-still fail fast to avoid known unstable LLVM 21 paths.
+conversion requires requesting optimization (for example, `-O 1`) and is
+supported only with `-t x86-64`; other optimized target combinations still fail
+fast to avoid known unstable LLVM 21 paths.
 
 ### Python API
 
@@ -103,7 +104,7 @@ cargo run --example rust_api
 
 Windows support is functional, but a few LLVM integration paths still differ from Linux and macOS:
 
-- Optimized conversion on Windows is currently supported only for `-t x86-64`; other optimized target combinations fail fast instead of entering known unstable LLVM paths.
+- Optimized conversion on Windows is currently supported only when optimization is requested (for example, `-O 1`) with `-t x86-64`; other optimized target combinations fail fast instead of entering known unstable LLVM paths.
 - LLVM verifier failures return a generic error on Windows instead of the full verifier message.
 - Native target codegen on Windows uses conservative CPU settings instead of host CPU feature detection.
 - `-O0` optimization on Windows is a validation-only fast path and does not rewrite the module triple.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ cargo run -- input.ll
 
 This generates `input.qis.bc` containing the compiled QIS bitcode.
 
-On Windows, the default mode is conservative: `-O 0 -t native`. Optimized
-conversion paths remain temporarily disabled there because the current LLVM 21
-integration can crash in those modes.
+On Windows, the default mode remains conservative: `-O 0 -t native`. Optimized
+conversion is supported with `-t x86-64`; other optimized target combinations
+still fail fast to avoid known unstable LLVM 21 paths.
 
 ### Python API
 
@@ -103,7 +103,7 @@ cargo run --example rust_api
 
 Windows support is functional, but a few LLVM integration paths still differ from Linux and macOS:
 
-- Optimized conversion currently fails fast on Windows with a clear error instead of entering the known unstable LLVM path.
+- Optimized conversion on Windows is currently supported only for `-t x86-64`; other optimized target combinations fail fast instead of entering known unstable LLVM paths.
 - LLVM verifier failures return a generic error on Windows instead of the full verifier message.
 - Native target codegen on Windows uses conservative CPU settings instead of host CPU feature detection.
 - `-O0` optimization on Windows is a validation-only fast path and does not rewrite the module triple.

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -2719,7 +2719,7 @@ entry:
     #[cfg(windows)]
     conversion_cases! {
     // Windows runs this as a smoke test instead of snapshot matching because
-    // cross-target (`aarch64`) optimized codegen in CI has shown backend
+    // broad cross-target (`aarch64`) optimized codegen in CI has shown backend
     // instability and non-deterministic output differences. Re-checked on
     // Windows Arm64 on March 23, 2026: the new dynamic-allocation fixtures are
     // stable under this `-O0`/`native` conversion+parse path, and the remaining
@@ -2738,4 +2738,18 @@ entry:
             .expect("Compiled QIS bitcode should parse on Windows");
         assert!(parsed.get_function("qmain").is_some());
     }}
+
+    #[cfg(windows)]
+    #[test]
+    fn test_snapshot_conversion_windows_optimized_x86_64_smoke() {
+        let ll_path = Path::new("tests/data/base.ll");
+        let qir_bytes = get_qir_bytes(ll_path);
+        let qis_bytes = qir_qis::qir_to_qis(qir_bytes.into(), 1, "x86-64", None)
+            .expect("optimized Windows x86-64 conversion should succeed");
+
+        let context = Context::create();
+        let parsed = crate::parse_bitcode_module(&context, &qis_bytes, "qis_module")
+            .expect("optimized Windows QIS bitcode should parse");
+        assert!(parsed.get_function("qmain").is_some());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4891,9 +4891,21 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
 "#;
         let bc_bytes = qir_ll_to_bc(ll_text).unwrap();
         let err = qir_to_qis(&bc_bytes, 1, "native", None)
-            .expect_err("optimized conversion should fail fast on Windows");
-        assert!(err.contains("currently unavailable on Windows"));
+            .expect_err("optimized native conversion should fail fast on Windows");
+        assert!(err.contains("supported only for `target=\"x86-64\"`"));
         assert!(err.contains("opt_level=0"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_windows_optimized_x86_64_conversion_smoke() {
+        let bc_bytes = load_fixture_bitcode("tests/data/base.ll");
+        let output_bc = qir_to_qis(&bc_bytes, 1, "x86-64", None)
+            .expect("optimized x86-64 conversion should succeed on Windows");
+        let ctx = Context::create();
+        let module = parse_bitcode_module(&ctx, &output_bc, "optimized_windows_qis")
+            .expect("optimized Windows output should parse");
+        assert!(module.get_function("qmain").is_some());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4909,6 +4909,14 @@ attributes #0 = { "entry_point" "qir_profiles"="base_profile" "output_labeling_s
     }
 
     #[test]
+    fn test_invalid_target_reports_invalid_architecture_even_when_optimized_requested() {
+        let bc_bytes = load_fixture_bitcode("tests/data/base.ll");
+        let err = qir_to_qis(&bc_bytes, 1, "invalid-target", None)
+            .expect_err("invalid targets should fail before platform-specific optimized guards");
+        assert!(err.contains("Invalid target architecture: invalid-target"));
+    }
+
+    #[test]
     fn test_qir_ll_to_bc_accepts_legacy_typed_pointers() {
         let ll_text =
             std::fs::read_to_string("tests/data/base.ll").expect("Failed to read base.ll");

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -90,8 +90,11 @@ fn get_target_machine(target: &str, opt_level: OptimizationLevel) -> Result<Targ
 /// # Errors
 /// Returns an error if module verification fails
 pub fn optimize(module: &Module, opt_level: u32, target: &str) -> Result<(), String> {
+    let target_config =
+        get_target_config(target).map_err(|e| format!("Failed to get target machine: {e}"))?;
+
     #[cfg(windows)]
-    if opt_level > 0 && target != WINDOWS_STABLE_OPT_TARGET {
+    if opt_level > 0 && target_config != X86_CONFIG {
         return Err(format!(
             "Optimized QIR-to-QIS conversion on Windows with LLVM 21 is currently supported only for `target=\"x86-64\"`. Re-run with `target=\"x86-64\"` for optimized conversion, or use `opt_level=0` with `target=\"native\"` for the conservative path (requested opt_level={opt_level}, target=\"{target}\")."
         ));
@@ -101,8 +104,6 @@ pub fn optimize(module: &Module, opt_level: u32, target: &str) -> Result<(), Str
     // Avoid creating a TargetMachine in this mode; TargetMachine teardown has
     // caused access violations in some Windows environments.
     if opt_level == 0 {
-        let target_config =
-            get_target_config(target).map_err(|e| format!("Failed to get target machine: {e}"))?;
         #[cfg(not(windows))]
         {
             let triple = if target_config == NATIVE_CONFIG {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -88,8 +88,7 @@ fn get_target_machine(target: &str, opt_level: OptimizationLevel) -> Result<Targ
 /// Returns an error if module verification fails
 pub fn optimize(module: &Module, opt_level: u32, target: &str) -> Result<(), String> {
     let target_config =
-        get_target_config(target).map_err(|e| format!("Failed to get target machine: {e}"))?;
-
+        get_target_config(target).map_err(|e| format!("Failed to get target config: {e}"))?;
     #[cfg(windows)]
     if opt_level > 0 && target_config != X86_CONFIG {
         return Err(format!(

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -131,6 +131,14 @@ pub fn optimize(module: &Module, opt_level: u32, target: &str) -> Result<(), Str
     let target_machine = get_target_machine(target, opt)
         .map_err(|e| format!("Failed to get target machine: {e}"))?;
 
+    #[cfg(windows)]
+    {
+        let (_, _, triple, _) = target_config;
+        module.set_triple(&TargetTriple::create(triple));
+        let data_layout = target_machine.get_target_data().get_data_layout();
+        module.set_data_layout(&data_layout);
+    }
+
     #[cfg(not(windows))]
     {
         let (data_layout, triple) = {

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -31,6 +31,9 @@ const X86_CONFIG: TargetConfig = ("x86-64", "x86-64", "x86_64-unknown-linux-gnu"
 /// Sentinel config for native codegen target
 const NATIVE_CONFIG: TargetConfig = ("", "", "", "");
 
+#[cfg(windows)]
+const WINDOWS_STABLE_OPT_TARGET: &str = "x86-64";
+
 fn get_target_config(target: &str) -> Result<TargetConfig<'_>, String> {
     match target {
         "x86-64" => Ok(X86_CONFIG),
@@ -88,9 +91,9 @@ fn get_target_machine(target: &str, opt_level: OptimizationLevel) -> Result<Targ
 /// Returns an error if module verification fails
 pub fn optimize(module: &Module, opt_level: u32, target: &str) -> Result<(), String> {
     #[cfg(windows)]
-    if opt_level > 0 {
+    if opt_level > 0 && target != WINDOWS_STABLE_OPT_TARGET {
         return Err(format!(
-            "Optimized QIR-to-QIS conversion is currently unavailable on Windows with the LLVM 21 integration. Re-run with `opt_level=0` and preferably `target=\"native\"` (requested opt_level={opt_level}, target=\"{target}\")."
+            "Optimized QIR-to-QIS conversion on Windows with LLVM 21 is currently supported only for `target=\"x86-64\"`. Re-run with `target=\"x86-64\"` for optimized conversion, or use `opt_level=0` with `target=\"native\"` for the conservative path (requested opt_level={opt_level}, target=\"{target}\")."
         ));
     }
 
@@ -127,14 +130,17 @@ pub fn optimize(module: &Module, opt_level: u32, target: &str) -> Result<(), Str
     let target_machine = get_target_machine(target, opt)
         .map_err(|e| format!("Failed to get target machine: {e}"))?;
 
-    let (data_layout, triple) = {
-        (
-            target_machine.get_target_data().get_data_layout(),
-            target_machine.get_triple(),
-        )
-    };
-    module.set_triple(&triple);
-    module.set_data_layout(&data_layout);
+    #[cfg(not(windows))]
+    {
+        let (data_layout, triple) = {
+            (
+                target_machine.get_target_data().get_data_layout(),
+                target_machine.get_triple(),
+            )
+        };
+        module.set_triple(&triple);
+        module.set_data_layout(&data_layout);
+    }
     module
         .run_passes(opt_str, &target_machine, PassBuilderOptions::create())
         .map_err(|e| format!("Failed to run passes: {e}"))?;

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -26,7 +26,12 @@ const AARCH64_CONFIG: TargetConfig = (
 );
 
 /// Default config for x86-64 codegen target
+#[cfg(not(windows))]
 const X86_CONFIG: TargetConfig = ("x86-64", "x86-64", "x86_64-unknown-linux-gnu", "");
+
+/// Default config for x86-64 codegen target on Windows (uses MSVC triple)
+#[cfg(windows)]
+const X86_CONFIG: TargetConfig = ("x86-64", "x86-64", "x86_64-pc-windows-msvc", "");
 
 /// Sentinel config for native codegen target
 const NATIVE_CONFIG: TargetConfig = ("", "", "", "");
@@ -209,5 +214,22 @@ mod tests {
 
         let triple = module.get_triple().as_str().to_string_lossy().into_owned();
         assert_eq!(triple, "x86_64-unknown-linux-gnu");
+    }
+
+    /// On Windows the x86-64 optimized path must embed a Windows MSVC triple, not the Linux one.
+    #[cfg(windows)]
+    #[test]
+    fn test_optimize_windows_x86_64_sets_windows_triple() {
+        use super::optimize;
+        use inkwell::context::Context;
+
+        let context = Context::create();
+        let module = context.create_module("test");
+        optimize(&module, 1, "x86-64").expect("Windows x86-64 O1 optimize should succeed");
+        let triple = module.get_triple().as_str().to_string_lossy().into_owned();
+        assert_eq!(
+            triple, "x86_64-pc-windows-msvc",
+            "Windows optimized path must set the MSVC triple, not the Linux cross-compile triple"
+        );
     }
 }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -31,9 +31,6 @@ const X86_CONFIG: TargetConfig = ("x86-64", "x86-64", "x86_64-unknown-linux-gnu"
 /// Sentinel config for native codegen target
 const NATIVE_CONFIG: TargetConfig = ("", "", "", "");
 
-#[cfg(windows)]
-const WINDOWS_STABLE_OPT_TARGET: &str = "x86-64";
-
 fn get_target_config(target: &str) -> Result<TargetConfig<'_>, String> {
     match target {
         "x86-64" => Ok(X86_CONFIG),


### PR DESCRIPTION
## Summary
- allow optimized Windows conversion only on the stable x86-64 target while preserving the conservative opt_level=0 + target="native" path
- keep Windows guardrails explicit with actionable errors for unsupported optimized target combinations
- add Windows optimized end-to-end conversion smoke coverage in src/convert.rs and src/lib.rs
- keep broad Windows fixture coverage on the existing O0 smoke path while restoring real optimized-path CI signal

## Testing
- make test
- make lint (fails in this environment on pre-existing uvx ty check unresolved external Python imports in main.py and examples/python_api.py)

Fixes #45