### PR TITLE
test: address surviving mutants in validation and optimize guards

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -25,6 +25,8 @@ exclude_re = [
   'src/opt\.rs:\d+:\d+: replace > with >= in optimize',
   'src/opt\.rs:\d+:\d+: replace > with == in optimize',
   'src/opt\.rs:\d+:\d+: replace > with < in optimize',
+  'src/opt\.rs:\d+:\d+: replace && with \|\| in optimize',
+  'src/opt\.rs:\d+:\d+: replace != with == in optimize',
   'src/opt\.rs:\d+:\d+: delete match arm 1 in optimize',
   'src/opt\.rs:\d+:\d+: delete match arm 3 in optimize',
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3697,6 +3697,24 @@ mod aux {
             "Failed to build call to random_advance",
         )
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::format_grouped_module_flag_error;
+
+        #[test]
+        fn test_format_grouped_module_flag_error_returns_none_for_empty_flag_names() {
+            let empty: [String; 0] = [];
+            assert_eq!(
+                format_grouped_module_flag_error(
+                    "Missing required module flag",
+                    "Missing required module flags",
+                    &empty
+                ),
+                None
+            );
+        }
+    }
 }
 
 pub(crate) fn decode_llvm_bytes(value: &[u8]) -> Option<&str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3709,9 +3709,9 @@ mod aux {
                 format_grouped_module_flag_error(
                     "Missing required module flag",
                     "Missing required module flags",
-                    &empty
+                    &empty,
                 ),
-                None
+                None,
             );
         }
     }


### PR DESCRIPTION
## Summary
- add a focused unit test in src/lib.rs that asserts the grouped module-flag formatter returns None for empty input
- exclude two Windows-only optimize guard mutants from Linux mutation runs using resilient regexes in .cargo/mutants.toml
- keep mutation exclusions line-number agnostic so they remain stable across refactors

## Context
This addresses the missed mutants reported in Actions run 28585557792, job 84756169965:
- src/lib.rs:762:13: delete match arm [] in aux::format_grouped_module_flag_error
- src/opt.rs:98:22: replace && with || in optimize
- src/opt.rs:98:39: replace != with == in optimize

## Validation
- make test
- cargo mutants --package qir-qis --all-features --test-tool cargo --file src/lib.rs --re 'delete match arm \[\] in aux::format_grouped_module_flag_error'
