### PR TITLE
ci(deps): include fuzz workspace in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,11 @@ updates:
       # Keep llvm-sys aligned with inkwell, CI images, and the installed LLVM toolchain.
       # Standalone bumps create unusable PRs (for example llvm-sys 221 while the repo is on LLVM 21).
       - dependency-name: "llvm-sys"
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+    groups:
+      wasm:
+        patterns:
+          - "wasm*"


### PR DESCRIPTION
## Summary

- Add weekly Cargo Dependabot updates for the separate fuzz workspace.
- Group `wasm*` updates in the fuzz workspace, matching the root workspace policy.
- Ensure updates to `fuzz/Cargo.toml` and `fuzz/Cargo.lock` are proposed automatically.

## Validation

- YAML parse check
- `make test` (221 Rust tests plus Python smoke)
- `make lint` (pre-commit checks passed; `ty` is blocked by unresolved optional/example imports in the local Python 3.14 environment)
