### PR TITLE
ci: bootstrap sccache without wrapper

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -128,6 +128,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: cargo-bins/cargo-binstall@v1.21.1
       - name: Install lint tools
+        # `cargo-binstall` may fall back to `cargo install` when GitHub API
+        # rate limiting prevents fetching a prebuilt `sccache` release.
+        # Do not configure `sccache` as the wrapper until it exists.
+        env:
+          RUSTC_WRAPPER: ""
         run: |
           cargo binstall --no-confirm --force sccache
           if [ "${{ github.event_name }}" != "pull_request" ]; then


### PR DESCRIPTION
## Summary

- clear `RUSTC_WRAPPER` only while `cargo-binstall` bootstraps `sccache` and `cargo-msrv`
- retain the job-level `sccache` wrapper after its executable has been installed

## Why this is needed

[`main` CI run 32368701129](https://github.com/Quantinuum/qir-qis/actions/runs/32368701129/job/96424010560) failed before it reached the lint commands. GitHub returned `403 Forbidden` while `cargo-binstall` looked up the prebuilt `sccache` release, causing it to fall back to `cargo install sccache`.

The lint job configures `RUSTC_WRAPPER=sccache` at job scope. During that fallback, Cargo therefore attempted to execute `sccache rustc -vV` before `sccache` had been installed and failed with `No such file or directory`.

This change clears the wrapper only in the bootstrap step. Once that step finishes, the job-level wrapper is in effect again for the cache and lint compilation steps, so the normal `sccache` behavior is preserved.

## Validation

- YAML parse check
- `make test` (221 Rust tests plus Python smoke)
- `make lint` (pre-commit checks passed; local `ty` remains blocked by unresolved optional/example imports in the Python 3.14 environment)
