### PR TITLE
fix(convert): improve error message for missing required_num_qubits attribute

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -319,7 +319,7 @@ pub fn get_required_num_qubits(function: FunctionValue) -> Option<u32> {
 pub fn get_required_num_qubits_strict(function: FunctionValue) -> Result<u32, String> {
     let attr = function
         .get_string_attribute(AttributeLoc::Function, "required_num_qubits")
-        .ok_or("Missing or invalid required_num_qubits attribute")?;
+        .ok_or("Missing required_num_qubits attribute")?;
     let raw = decode_llvm_c_string(attr.get_string_value())
         .ok_or_else(|| "Invalid required_num_qubits attribute (not UTF-8)".to_string())?;
     raw.parse::<u32>()
@@ -1562,6 +1562,24 @@ mod tests {
         assert_eq!(
             func.as_global_value().as_pointer_value(),
             func2.as_global_value().as_pointer_value()
+        );
+    }
+
+    #[test]
+    fn test_get_required_num_qubits_strict_returns_missing_error() {
+        let context = Context::create();
+        let module = context.create_module("test");
+        let fn_type = context.void_type().fn_type(&[], false);
+        let func = module.add_function("entry", fn_type, None);
+        let entry_block = context.append_basic_block(func, "entry");
+        let builder = context.create_builder();
+        builder.position_at_end(entry_block);
+        let _ = builder.build_return(None);
+
+        let result = get_required_num_qubits_strict(func);
+        assert_eq!(
+            result.unwrap_err(),
+            "Missing required_num_qubits attribute"
         );
     }
 


### PR DESCRIPTION
## Summary

The error message `'Missing or invalid required_num_qubits attribute'` in `get_required_num_qubits_strict` was misleading. If the attribute existed, the code would proceed to handle UTF-8 decoding and parsing errors separately. The new message `'Missing required_num_qubits attribute'` accurately tells users the attribute is absent, helping them quickly identify and fix the root cause.

## Changes

- **src/convert.rs**: Changed error message from `"Missing or invalid required_num_qubits attribute"` to `"Missing required_num_qubits attribute"`
- **src/convert.rs**: Added regression test `test_get_required_num_qubits_strict_returns_missing_error`

## Testing

All 222 tests pass with LLVM 21:

```
test convert::tests::test_get_required_num_qubits_strict_returns_missing_error ... ok
test result: ok. 222 passed; 0 failed; 0 ignored
```